### PR TITLE
implement store integration without showing wallet history, wallet balance and Apple pay

### DIFF
--- a/lib/application/auth/password/password_bloc.dart
+++ b/lib/application/auth/password/password_bloc.dart
@@ -40,7 +40,7 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
             final response = await _apiService.signIn(
               AuthInfo(
                 phoneNumber: state.phoneNumber,
-                password: 'qwerty123',
+                password: state.password,
               ),
             );
             response.fold(

--- a/lib/application/chat/chat_list/chat_list_cubit.dart
+++ b/lib/application/chat/chat_list/chat_list_cubit.dart
@@ -1,6 +1,6 @@
+import 'package:astra_app/domain/core/failure/failure.dart';
 import 'package:astra_app/infrastructure/chat/chat.dart';
 import 'package:astra_app/infrastructure/chat/models/chat/chat.dart';
-import 'package:astra_app/domain/core/failure/failure.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 

--- a/lib/application/settings/store/store_actor/store_actor_bloc.dart
+++ b/lib/application/settings/store/store_actor/store_actor_bloc.dart
@@ -1,0 +1,25 @@
+import 'package:astra_app/domain/store/models/like.dart';
+import 'package:bloc/bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+
+part 'store_actor_event.dart';
+part 'store_actor_state.dart';
+part 'store_actor_bloc.freezed.dart';
+
+/// Defines bloc for store screen.
+@injectable
+class StoreActorBloc extends Bloc<StoreActorEvent, StoreActorState> {
+  StoreActorBloc() : super(StoreActorState.initial()) {
+    on<StoreActorEvent>((event, emit) async {
+      await event.map(
+        initialized: (e) async {
+          emit(state.copyWith(likes: e.likes, like: e.likes[1]));
+        },
+        likePackageSelected: (e) async {
+          emit(state.copyWith(like: e.like));
+        },
+      );
+    });
+  }
+}

--- a/lib/application/settings/store/store_actor/store_actor_bloc.freezed.dart
+++ b/lib/application/settings/store/store_actor/store_actor_bloc.freezed.dart
@@ -1,0 +1,532 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'store_actor_bloc.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$StoreActorEventTearOff {
+  const _$StoreActorEventTearOff();
+
+  _Initialized initialized(List<Like> likes) {
+    return _Initialized(
+      likes,
+    );
+  }
+
+  _LikePackageSelected likePackageSelected(Like like) {
+    return _LikePackageSelected(
+      like,
+    );
+  }
+}
+
+/// @nodoc
+const $StoreActorEvent = _$StoreActorEventTearOff();
+
+/// @nodoc
+mixin _$StoreActorEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<Like> likes) initialized,
+    required TResult Function(Like like) likePackageSelected,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<Like> likes)? initialized,
+    TResult Function(Like like)? likePackageSelected,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<Like> likes)? initialized,
+    TResult Function(Like like)? likePackageSelected,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_LikePackageSelected value) likePackageSelected,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_LikePackageSelected value)? likePackageSelected,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_LikePackageSelected value)? likePackageSelected,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StoreActorEventCopyWith<$Res> {
+  factory $StoreActorEventCopyWith(
+          StoreActorEvent value, $Res Function(StoreActorEvent) then) =
+      _$StoreActorEventCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$StoreActorEventCopyWithImpl<$Res>
+    implements $StoreActorEventCopyWith<$Res> {
+  _$StoreActorEventCopyWithImpl(this._value, this._then);
+
+  final StoreActorEvent _value;
+  // ignore: unused_field
+  final $Res Function(StoreActorEvent) _then;
+}
+
+/// @nodoc
+abstract class _$InitializedCopyWith<$Res> {
+  factory _$InitializedCopyWith(
+          _Initialized value, $Res Function(_Initialized) then) =
+      __$InitializedCopyWithImpl<$Res>;
+  $Res call({List<Like> likes});
+}
+
+/// @nodoc
+class __$InitializedCopyWithImpl<$Res>
+    extends _$StoreActorEventCopyWithImpl<$Res>
+    implements _$InitializedCopyWith<$Res> {
+  __$InitializedCopyWithImpl(
+      _Initialized _value, $Res Function(_Initialized) _then)
+      : super(_value, (v) => _then(v as _Initialized));
+
+  @override
+  _Initialized get _value => super._value as _Initialized;
+
+  @override
+  $Res call({
+    Object? likes = freezed,
+  }) {
+    return _then(_Initialized(
+      likes == freezed
+          ? _value.likes
+          : likes // ignore: cast_nullable_to_non_nullable
+              as List<Like>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Initialized implements _Initialized {
+  const _$_Initialized(this.likes);
+
+  @override
+  final List<Like> likes;
+
+  @override
+  String toString() {
+    return 'StoreActorEvent.initialized(likes: $likes)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Initialized &&
+            const DeepCollectionEquality().equals(other.likes, likes));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(likes));
+
+  @JsonKey(ignore: true)
+  @override
+  _$InitializedCopyWith<_Initialized> get copyWith =>
+      __$InitializedCopyWithImpl<_Initialized>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<Like> likes) initialized,
+    required TResult Function(Like like) likePackageSelected,
+  }) {
+    return initialized(likes);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<Like> likes)? initialized,
+    TResult Function(Like like)? likePackageSelected,
+  }) {
+    return initialized?.call(likes);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<Like> likes)? initialized,
+    TResult Function(Like like)? likePackageSelected,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(likes);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_LikePackageSelected value) likePackageSelected,
+  }) {
+    return initialized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_LikePackageSelected value)? likePackageSelected,
+  }) {
+    return initialized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_LikePackageSelected value)? likePackageSelected,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initialized implements StoreActorEvent {
+  const factory _Initialized(List<Like> likes) = _$_Initialized;
+
+  List<Like> get likes;
+  @JsonKey(ignore: true)
+  _$InitializedCopyWith<_Initialized> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$LikePackageSelectedCopyWith<$Res> {
+  factory _$LikePackageSelectedCopyWith(_LikePackageSelected value,
+          $Res Function(_LikePackageSelected) then) =
+      __$LikePackageSelectedCopyWithImpl<$Res>;
+  $Res call({Like like});
+
+  $LikeCopyWith<$Res> get like;
+}
+
+/// @nodoc
+class __$LikePackageSelectedCopyWithImpl<$Res>
+    extends _$StoreActorEventCopyWithImpl<$Res>
+    implements _$LikePackageSelectedCopyWith<$Res> {
+  __$LikePackageSelectedCopyWithImpl(
+      _LikePackageSelected _value, $Res Function(_LikePackageSelected) _then)
+      : super(_value, (v) => _then(v as _LikePackageSelected));
+
+  @override
+  _LikePackageSelected get _value => super._value as _LikePackageSelected;
+
+  @override
+  $Res call({
+    Object? like = freezed,
+  }) {
+    return _then(_LikePackageSelected(
+      like == freezed
+          ? _value.like
+          : like // ignore: cast_nullable_to_non_nullable
+              as Like,
+    ));
+  }
+
+  @override
+  $LikeCopyWith<$Res> get like {
+    return $LikeCopyWith<$Res>(_value.like, (value) {
+      return _then(_value.copyWith(like: value));
+    });
+  }
+}
+
+/// @nodoc
+
+class _$_LikePackageSelected implements _LikePackageSelected {
+  const _$_LikePackageSelected(this.like);
+
+  @override
+  final Like like;
+
+  @override
+  String toString() {
+    return 'StoreActorEvent.likePackageSelected(like: $like)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _LikePackageSelected &&
+            const DeepCollectionEquality().equals(other.like, like));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(like));
+
+  @JsonKey(ignore: true)
+  @override
+  _$LikePackageSelectedCopyWith<_LikePackageSelected> get copyWith =>
+      __$LikePackageSelectedCopyWithImpl<_LikePackageSelected>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<Like> likes) initialized,
+    required TResult Function(Like like) likePackageSelected,
+  }) {
+    return likePackageSelected(like);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<Like> likes)? initialized,
+    TResult Function(Like like)? likePackageSelected,
+  }) {
+    return likePackageSelected?.call(like);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<Like> likes)? initialized,
+    TResult Function(Like like)? likePackageSelected,
+    required TResult orElse(),
+  }) {
+    if (likePackageSelected != null) {
+      return likePackageSelected(like);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+    required TResult Function(_LikePackageSelected value) likePackageSelected,
+  }) {
+    return likePackageSelected(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_LikePackageSelected value)? likePackageSelected,
+  }) {
+    return likePackageSelected?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    TResult Function(_LikePackageSelected value)? likePackageSelected,
+    required TResult orElse(),
+  }) {
+    if (likePackageSelected != null) {
+      return likePackageSelected(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _LikePackageSelected implements StoreActorEvent {
+  const factory _LikePackageSelected(Like like) = _$_LikePackageSelected;
+
+  Like get like;
+  @JsonKey(ignore: true)
+  _$LikePackageSelectedCopyWith<_LikePackageSelected> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+class _$StoreActorStateTearOff {
+  const _$StoreActorStateTearOff();
+
+  _StoreActorState call({required List<Like> likes, required Like like}) {
+    return _StoreActorState(
+      likes: likes,
+      like: like,
+    );
+  }
+}
+
+/// @nodoc
+const $StoreActorState = _$StoreActorStateTearOff();
+
+/// @nodoc
+mixin _$StoreActorState {
+  List<Like> get likes => throw _privateConstructorUsedError;
+  Like get like => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $StoreActorStateCopyWith<StoreActorState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StoreActorStateCopyWith<$Res> {
+  factory $StoreActorStateCopyWith(
+          StoreActorState value, $Res Function(StoreActorState) then) =
+      _$StoreActorStateCopyWithImpl<$Res>;
+  $Res call({List<Like> likes, Like like});
+
+  $LikeCopyWith<$Res> get like;
+}
+
+/// @nodoc
+class _$StoreActorStateCopyWithImpl<$Res>
+    implements $StoreActorStateCopyWith<$Res> {
+  _$StoreActorStateCopyWithImpl(this._value, this._then);
+
+  final StoreActorState _value;
+  // ignore: unused_field
+  final $Res Function(StoreActorState) _then;
+
+  @override
+  $Res call({
+    Object? likes = freezed,
+    Object? like = freezed,
+  }) {
+    return _then(_value.copyWith(
+      likes: likes == freezed
+          ? _value.likes
+          : likes // ignore: cast_nullable_to_non_nullable
+              as List<Like>,
+      like: like == freezed
+          ? _value.like
+          : like // ignore: cast_nullable_to_non_nullable
+              as Like,
+    ));
+  }
+
+  @override
+  $LikeCopyWith<$Res> get like {
+    return $LikeCopyWith<$Res>(_value.like, (value) {
+      return _then(_value.copyWith(like: value));
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$StoreActorStateCopyWith<$Res>
+    implements $StoreActorStateCopyWith<$Res> {
+  factory _$StoreActorStateCopyWith(
+          _StoreActorState value, $Res Function(_StoreActorState) then) =
+      __$StoreActorStateCopyWithImpl<$Res>;
+  @override
+  $Res call({List<Like> likes, Like like});
+
+  @override
+  $LikeCopyWith<$Res> get like;
+}
+
+/// @nodoc
+class __$StoreActorStateCopyWithImpl<$Res>
+    extends _$StoreActorStateCopyWithImpl<$Res>
+    implements _$StoreActorStateCopyWith<$Res> {
+  __$StoreActorStateCopyWithImpl(
+      _StoreActorState _value, $Res Function(_StoreActorState) _then)
+      : super(_value, (v) => _then(v as _StoreActorState));
+
+  @override
+  _StoreActorState get _value => super._value as _StoreActorState;
+
+  @override
+  $Res call({
+    Object? likes = freezed,
+    Object? like = freezed,
+  }) {
+    return _then(_StoreActorState(
+      likes: likes == freezed
+          ? _value.likes
+          : likes // ignore: cast_nullable_to_non_nullable
+              as List<Like>,
+      like: like == freezed
+          ? _value.like
+          : like // ignore: cast_nullable_to_non_nullable
+              as Like,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_StoreActorState implements _StoreActorState {
+  const _$_StoreActorState({required this.likes, required this.like});
+
+  @override
+  final List<Like> likes;
+  @override
+  final Like like;
+
+  @override
+  String toString() {
+    return 'StoreActorState(likes: $likes, like: $like)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _StoreActorState &&
+            const DeepCollectionEquality().equals(other.likes, likes) &&
+            const DeepCollectionEquality().equals(other.like, like));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(likes),
+      const DeepCollectionEquality().hash(like));
+
+  @JsonKey(ignore: true)
+  @override
+  _$StoreActorStateCopyWith<_StoreActorState> get copyWith =>
+      __$StoreActorStateCopyWithImpl<_StoreActorState>(this, _$identity);
+}
+
+abstract class _StoreActorState implements StoreActorState {
+  const factory _StoreActorState(
+      {required List<Like> likes, required Like like}) = _$_StoreActorState;
+
+  @override
+  List<Like> get likes;
+  @override
+  Like get like;
+  @override
+  @JsonKey(ignore: true)
+  _$StoreActorStateCopyWith<_StoreActorState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/application/settings/store/store_actor/store_actor_event.dart
+++ b/lib/application/settings/store/store_actor/store_actor_event.dart
@@ -1,0 +1,12 @@
+part of 'store_actor_bloc.dart';
+
+/// Store actor state change events.
+@freezed
+class StoreActorEvent with _$StoreActorEvent {
+  /// Screen initialoization event.
+  const factory StoreActorEvent.initialized(List<Like> likes) = _Initialized;
+
+  /// Like package select change event.
+  const factory StoreActorEvent.likePackageSelected(Like like) =
+      _LikePackageSelected;
+}

--- a/lib/application/settings/store/store_actor/store_actor_state.dart
+++ b/lib/application/settings/store/store_actor/store_actor_state.dart
@@ -1,0 +1,14 @@
+part of 'store_actor_bloc.dart';
+
+/// Defines states for changing states in store screen.
+@freezed
+class StoreActorState with _$StoreActorState {
+  const factory StoreActorState({
+    required final List<Like> likes,
+    required final Like like,
+  }) = _StoreActorState;
+  factory StoreActorState.initial() => StoreActorState(
+        likes: [],
+        like: Like.empty(),
+      );
+}

--- a/lib/application/settings/store/store_bloc.dart
+++ b/lib/application/settings/store/store_bloc.dart
@@ -1,0 +1,26 @@
+import 'package:astra_app/domain/store/models/like.dart';
+import 'package:astra_app/domain/store/repositories/i_store_reposytory.dart';
+import 'package:bloc/bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+
+part 'store_event.dart';
+part 'store_state.dart';
+part 'store_bloc.freezed.dart';
+
+/// Defines bloc for store screen.
+@injectable
+class StoreBloc extends Bloc<StoreEvent, StoreState> {
+  /// Store api repository.
+  final IStoreReposytory _storeRepository;
+  StoreBloc(this._storeRepository) : super(const StoreState.initial()) {
+    on<StoreEvent>((event, emit) async {
+      await event.map(initialized: (e) async {
+        emit(const StoreState.loadInProgress());
+        final response = await _storeRepository.getLikePackages();
+        emit(response.fold((failure) => const StoreState.loadFailure(),
+            (success) => StoreState.loadSuccess(success)));
+      });
+    });
+  }
+}

--- a/lib/application/settings/store/store_bloc.freezed.dart
+++ b/lib/application/settings/store/store_bloc.freezed.dart
@@ -1,0 +1,763 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'store_bloc.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$StoreEventTearOff {
+  const _$StoreEventTearOff();
+
+  _Initialized initialized() {
+    return const _Initialized();
+  }
+}
+
+/// @nodoc
+const $StoreEvent = _$StoreEventTearOff();
+
+/// @nodoc
+mixin _$StoreEvent {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? initialized,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StoreEventCopyWith<$Res> {
+  factory $StoreEventCopyWith(
+          StoreEvent value, $Res Function(StoreEvent) then) =
+      _$StoreEventCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$StoreEventCopyWithImpl<$Res> implements $StoreEventCopyWith<$Res> {
+  _$StoreEventCopyWithImpl(this._value, this._then);
+
+  final StoreEvent _value;
+  // ignore: unused_field
+  final $Res Function(StoreEvent) _then;
+}
+
+/// @nodoc
+abstract class _$InitializedCopyWith<$Res> {
+  factory _$InitializedCopyWith(
+          _Initialized value, $Res Function(_Initialized) then) =
+      __$InitializedCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$InitializedCopyWithImpl<$Res> extends _$StoreEventCopyWithImpl<$Res>
+    implements _$InitializedCopyWith<$Res> {
+  __$InitializedCopyWithImpl(
+      _Initialized _value, $Res Function(_Initialized) _then)
+      : super(_value, (v) => _then(v as _Initialized));
+
+  @override
+  _Initialized get _value => super._value as _Initialized;
+}
+
+/// @nodoc
+
+class _$_Initialized implements _Initialized {
+  const _$_Initialized();
+
+  @override
+  String toString() {
+    return 'StoreEvent.initialized()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _Initialized);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initialized,
+  }) {
+    return initialized();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? initialized,
+  }) {
+    return initialized?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initialized,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initialized value) initialized,
+  }) {
+    return initialized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+  }) {
+    return initialized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initialized value)? initialized,
+    required TResult orElse(),
+  }) {
+    if (initialized != null) {
+      return initialized(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initialized implements StoreEvent {
+  const factory _Initialized() = _$_Initialized;
+}
+
+/// @nodoc
+class _$StoreStateTearOff {
+  const _$StoreStateTearOff();
+
+  _Initial initial() {
+    return const _Initial();
+  }
+
+  _LoadInProgress loadInProgress() {
+    return const _LoadInProgress();
+  }
+
+  _LoadSuccess loadSuccess(List<Like> likes) {
+    return _LoadSuccess(
+      likes,
+    );
+  }
+
+  _LoadFailure loadFailure() {
+    return const _LoadFailure();
+  }
+}
+
+/// @nodoc
+const $StoreState = _$StoreStateTearOff();
+
+/// @nodoc
+mixin _$StoreState {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loadInProgress,
+    required TResult Function(List<Like> likes) loadSuccess,
+    required TResult Function() loadFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_LoadInProgress value) loadInProgress,
+    required TResult Function(_LoadSuccess value) loadSuccess,
+    required TResult Function(_LoadFailure value) loadFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StoreStateCopyWith<$Res> {
+  factory $StoreStateCopyWith(
+          StoreState value, $Res Function(StoreState) then) =
+      _$StoreStateCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$StoreStateCopyWithImpl<$Res> implements $StoreStateCopyWith<$Res> {
+  _$StoreStateCopyWithImpl(this._value, this._then);
+
+  final StoreState _value;
+  // ignore: unused_field
+  final $Res Function(StoreState) _then;
+}
+
+/// @nodoc
+abstract class _$InitialCopyWith<$Res> {
+  factory _$InitialCopyWith(_Initial value, $Res Function(_Initial) then) =
+      __$InitialCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$InitialCopyWithImpl<$Res> extends _$StoreStateCopyWithImpl<$Res>
+    implements _$InitialCopyWith<$Res> {
+  __$InitialCopyWithImpl(_Initial _value, $Res Function(_Initial) _then)
+      : super(_value, (v) => _then(v as _Initial));
+
+  @override
+  _Initial get _value => super._value as _Initial;
+}
+
+/// @nodoc
+
+class _$_Initial implements _Initial {
+  const _$_Initial();
+
+  @override
+  String toString() {
+    return 'StoreState.initial()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _Initial);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loadInProgress,
+    required TResult Function(List<Like> likes) loadSuccess,
+    required TResult Function() loadFailure,
+  }) {
+    return initial();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+  }) {
+    return initial?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_LoadInProgress value) loadInProgress,
+    required TResult Function(_LoadSuccess value) loadSuccess,
+    required TResult Function(_LoadFailure value) loadFailure,
+  }) {
+    return initial(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+  }) {
+    return initial?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (initial != null) {
+      return initial(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Initial implements StoreState {
+  const factory _Initial() = _$_Initial;
+}
+
+/// @nodoc
+abstract class _$LoadInProgressCopyWith<$Res> {
+  factory _$LoadInProgressCopyWith(
+          _LoadInProgress value, $Res Function(_LoadInProgress) then) =
+      __$LoadInProgressCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$LoadInProgressCopyWithImpl<$Res> extends _$StoreStateCopyWithImpl<$Res>
+    implements _$LoadInProgressCopyWith<$Res> {
+  __$LoadInProgressCopyWithImpl(
+      _LoadInProgress _value, $Res Function(_LoadInProgress) _then)
+      : super(_value, (v) => _then(v as _LoadInProgress));
+
+  @override
+  _LoadInProgress get _value => super._value as _LoadInProgress;
+}
+
+/// @nodoc
+
+class _$_LoadInProgress implements _LoadInProgress {
+  const _$_LoadInProgress();
+
+  @override
+  String toString() {
+    return 'StoreState.loadInProgress()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _LoadInProgress);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loadInProgress,
+    required TResult Function(List<Like> likes) loadSuccess,
+    required TResult Function() loadFailure,
+  }) {
+    return loadInProgress();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+  }) {
+    return loadInProgress?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (loadInProgress != null) {
+      return loadInProgress();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_LoadInProgress value) loadInProgress,
+    required TResult Function(_LoadSuccess value) loadSuccess,
+    required TResult Function(_LoadFailure value) loadFailure,
+  }) {
+    return loadInProgress(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+  }) {
+    return loadInProgress?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (loadInProgress != null) {
+      return loadInProgress(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _LoadInProgress implements StoreState {
+  const factory _LoadInProgress() = _$_LoadInProgress;
+}
+
+/// @nodoc
+abstract class _$LoadSuccessCopyWith<$Res> {
+  factory _$LoadSuccessCopyWith(
+          _LoadSuccess value, $Res Function(_LoadSuccess) then) =
+      __$LoadSuccessCopyWithImpl<$Res>;
+  $Res call({List<Like> likes});
+}
+
+/// @nodoc
+class __$LoadSuccessCopyWithImpl<$Res> extends _$StoreStateCopyWithImpl<$Res>
+    implements _$LoadSuccessCopyWith<$Res> {
+  __$LoadSuccessCopyWithImpl(
+      _LoadSuccess _value, $Res Function(_LoadSuccess) _then)
+      : super(_value, (v) => _then(v as _LoadSuccess));
+
+  @override
+  _LoadSuccess get _value => super._value as _LoadSuccess;
+
+  @override
+  $Res call({
+    Object? likes = freezed,
+  }) {
+    return _then(_LoadSuccess(
+      likes == freezed
+          ? _value.likes
+          : likes // ignore: cast_nullable_to_non_nullable
+              as List<Like>,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_LoadSuccess implements _LoadSuccess {
+  const _$_LoadSuccess(this.likes);
+
+  @override
+  final List<Like> likes;
+
+  @override
+  String toString() {
+    return 'StoreState.loadSuccess(likes: $likes)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _LoadSuccess &&
+            const DeepCollectionEquality().equals(other.likes, likes));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(likes));
+
+  @JsonKey(ignore: true)
+  @override
+  _$LoadSuccessCopyWith<_LoadSuccess> get copyWith =>
+      __$LoadSuccessCopyWithImpl<_LoadSuccess>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loadInProgress,
+    required TResult Function(List<Like> likes) loadSuccess,
+    required TResult Function() loadFailure,
+  }) {
+    return loadSuccess(likes);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+  }) {
+    return loadSuccess?.call(likes);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (loadSuccess != null) {
+      return loadSuccess(likes);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_LoadInProgress value) loadInProgress,
+    required TResult Function(_LoadSuccess value) loadSuccess,
+    required TResult Function(_LoadFailure value) loadFailure,
+  }) {
+    return loadSuccess(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+  }) {
+    return loadSuccess?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (loadSuccess != null) {
+      return loadSuccess(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _LoadSuccess implements StoreState {
+  const factory _LoadSuccess(List<Like> likes) = _$_LoadSuccess;
+
+  List<Like> get likes;
+  @JsonKey(ignore: true)
+  _$LoadSuccessCopyWith<_LoadSuccess> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$LoadFailureCopyWith<$Res> {
+  factory _$LoadFailureCopyWith(
+          _LoadFailure value, $Res Function(_LoadFailure) then) =
+      __$LoadFailureCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$LoadFailureCopyWithImpl<$Res> extends _$StoreStateCopyWithImpl<$Res>
+    implements _$LoadFailureCopyWith<$Res> {
+  __$LoadFailureCopyWithImpl(
+      _LoadFailure _value, $Res Function(_LoadFailure) _then)
+      : super(_value, (v) => _then(v as _LoadFailure));
+
+  @override
+  _LoadFailure get _value => super._value as _LoadFailure;
+}
+
+/// @nodoc
+
+class _$_LoadFailure implements _LoadFailure {
+  const _$_LoadFailure();
+
+  @override
+  String toString() {
+    return 'StoreState.loadFailure()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _LoadFailure);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function() initial,
+    required TResult Function() loadInProgress,
+    required TResult Function(List<Like> likes) loadSuccess,
+    required TResult Function() loadFailure,
+  }) {
+    return loadFailure();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+  }) {
+    return loadFailure?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function()? initial,
+    TResult Function()? loadInProgress,
+    TResult Function(List<Like> likes)? loadSuccess,
+    TResult Function()? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (loadFailure != null) {
+      return loadFailure();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Initial value) initial,
+    required TResult Function(_LoadInProgress value) loadInProgress,
+    required TResult Function(_LoadSuccess value) loadSuccess,
+    required TResult Function(_LoadFailure value) loadFailure,
+  }) {
+    return loadFailure(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+  }) {
+    return loadFailure?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Initial value)? initial,
+    TResult Function(_LoadInProgress value)? loadInProgress,
+    TResult Function(_LoadSuccess value)? loadSuccess,
+    TResult Function(_LoadFailure value)? loadFailure,
+    required TResult orElse(),
+  }) {
+    if (loadFailure != null) {
+      return loadFailure(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _LoadFailure implements StoreState {
+  const factory _LoadFailure() = _$_LoadFailure;
+}

--- a/lib/application/settings/store/store_event.dart
+++ b/lib/application/settings/store/store_event.dart
@@ -1,0 +1,8 @@
+part of 'store_bloc.dart';
+
+/// Store state change events.
+@freezed
+class StoreEvent with _$StoreEvent {
+  /// Screen initialoization event.
+  const factory StoreEvent.initialized() = _Initialized;
+}

--- a/lib/application/settings/store/store_state.dart
+++ b/lib/application/settings/store/store_state.dart
@@ -1,0 +1,19 @@
+part of 'store_bloc.dart';
+
+/// Defines states for store screen.
+@freezed
+class StoreState with _$StoreState {
+  /// Initial states loaded.
+  const factory StoreState.initial() = _Initial;
+
+  /// Progress loading states.
+  const factory StoreState.loadInProgress() = _LoadInProgress;
+
+  /// Successfule loaded data state.
+  ///
+  /// Keep state of list [Like] if loaded successfully.
+  const factory StoreState.loadSuccess(List<Like> likes) = _LoadSuccess;
+
+  /// Unsuccessfully loaded data state.
+  const factory StoreState.loadFailure() = _LoadFailure;
+}

--- a/lib/domain/core/failure/astra_failure.dart
+++ b/lib/domain/core/failure/astra_failure.dart
@@ -1,0 +1,10 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'astra_failure.freezed.dart';
+
+/// Represent union of astra failure.
+@freezed
+class AstraFailure with _$AstraFailure {
+  const AstraFailure._();
+  const factory AstraFailure.api([int? errorCode]) = _Api;
+  const factory AstraFailure.noConnection() = _NoConnection;
+}

--- a/lib/domain/core/failure/astra_failure.freezed.dart
+++ b/lib/domain/core/failure/astra_failure.freezed.dart
@@ -1,0 +1,326 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'astra_failure.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$AstraFailureTearOff {
+  const _$AstraFailureTearOff();
+
+  _Api api([int? errorCode]) {
+    return _Api(
+      errorCode,
+    );
+  }
+
+  _NoConnection noConnection() {
+    return const _NoConnection();
+  }
+}
+
+/// @nodoc
+const $AstraFailure = _$AstraFailureTearOff();
+
+/// @nodoc
+mixin _$AstraFailure {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int? errorCode) api,
+    required TResult Function() noConnection,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(int? errorCode)? api,
+    TResult Function()? noConnection,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int? errorCode)? api,
+    TResult Function()? noConnection,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Api value) api,
+    required TResult Function(_NoConnection value) noConnection,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Api value)? api,
+    TResult Function(_NoConnection value)? noConnection,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Api value)? api,
+    TResult Function(_NoConnection value)? noConnection,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AstraFailureCopyWith<$Res> {
+  factory $AstraFailureCopyWith(
+          AstraFailure value, $Res Function(AstraFailure) then) =
+      _$AstraFailureCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$AstraFailureCopyWithImpl<$Res> implements $AstraFailureCopyWith<$Res> {
+  _$AstraFailureCopyWithImpl(this._value, this._then);
+
+  final AstraFailure _value;
+  // ignore: unused_field
+  final $Res Function(AstraFailure) _then;
+}
+
+/// @nodoc
+abstract class _$ApiCopyWith<$Res> {
+  factory _$ApiCopyWith(_Api value, $Res Function(_Api) then) =
+      __$ApiCopyWithImpl<$Res>;
+  $Res call({int? errorCode});
+}
+
+/// @nodoc
+class __$ApiCopyWithImpl<$Res> extends _$AstraFailureCopyWithImpl<$Res>
+    implements _$ApiCopyWith<$Res> {
+  __$ApiCopyWithImpl(_Api _value, $Res Function(_Api) _then)
+      : super(_value, (v) => _then(v as _Api));
+
+  @override
+  _Api get _value => super._value as _Api;
+
+  @override
+  $Res call({
+    Object? errorCode = freezed,
+  }) {
+    return _then(_Api(
+      errorCode == freezed
+          ? _value.errorCode
+          : errorCode // ignore: cast_nullable_to_non_nullable
+              as int?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Api extends _Api {
+  const _$_Api([this.errorCode]) : super._();
+
+  @override
+  final int? errorCode;
+
+  @override
+  String toString() {
+    return 'AstraFailure.api(errorCode: $errorCode)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Api &&
+            const DeepCollectionEquality().equals(other.errorCode, errorCode));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(errorCode));
+
+  @JsonKey(ignore: true)
+  @override
+  _$ApiCopyWith<_Api> get copyWith =>
+      __$ApiCopyWithImpl<_Api>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int? errorCode) api,
+    required TResult Function() noConnection,
+  }) {
+    return api(errorCode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(int? errorCode)? api,
+    TResult Function()? noConnection,
+  }) {
+    return api?.call(errorCode);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int? errorCode)? api,
+    TResult Function()? noConnection,
+    required TResult orElse(),
+  }) {
+    if (api != null) {
+      return api(errorCode);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Api value) api,
+    required TResult Function(_NoConnection value) noConnection,
+  }) {
+    return api(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Api value)? api,
+    TResult Function(_NoConnection value)? noConnection,
+  }) {
+    return api?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Api value)? api,
+    TResult Function(_NoConnection value)? noConnection,
+    required TResult orElse(),
+  }) {
+    if (api != null) {
+      return api(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _Api extends AstraFailure {
+  const factory _Api([int? errorCode]) = _$_Api;
+  const _Api._() : super._();
+
+  int? get errorCode;
+  @JsonKey(ignore: true)
+  _$ApiCopyWith<_Api> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$NoConnectionCopyWith<$Res> {
+  factory _$NoConnectionCopyWith(
+          _NoConnection value, $Res Function(_NoConnection) then) =
+      __$NoConnectionCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class __$NoConnectionCopyWithImpl<$Res> extends _$AstraFailureCopyWithImpl<$Res>
+    implements _$NoConnectionCopyWith<$Res> {
+  __$NoConnectionCopyWithImpl(
+      _NoConnection _value, $Res Function(_NoConnection) _then)
+      : super(_value, (v) => _then(v as _NoConnection));
+
+  @override
+  _NoConnection get _value => super._value as _NoConnection;
+}
+
+/// @nodoc
+
+class _$_NoConnection extends _NoConnection {
+  const _$_NoConnection() : super._();
+
+  @override
+  String toString() {
+    return 'AstraFailure.noConnection()';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType && other is _NoConnection);
+  }
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int? errorCode) api,
+    required TResult Function() noConnection,
+  }) {
+    return noConnection();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(int? errorCode)? api,
+    TResult Function()? noConnection,
+  }) {
+    return noConnection?.call();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int? errorCode)? api,
+    TResult Function()? noConnection,
+    required TResult orElse(),
+  }) {
+    if (noConnection != null) {
+      return noConnection();
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(_Api value) api,
+    required TResult Function(_NoConnection value) noConnection,
+  }) {
+    return noConnection(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(_Api value)? api,
+    TResult Function(_NoConnection value)? noConnection,
+  }) {
+    return noConnection?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(_Api value)? api,
+    TResult Function(_NoConnection value)? noConnection,
+    required TResult orElse(),
+  }) {
+    if (noConnection != null) {
+      return noConnection(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class _NoConnection extends AstraFailure {
+  const factory _NoConnection() = _$_NoConnection;
+  const _NoConnection._() : super._();
+}

--- a/lib/domain/store/models/like.dart
+++ b/lib/domain/store/models/like.dart
@@ -1,0 +1,38 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'like.freezed.dart';
+
+/// Represent like package.
+@freezed
+class Like with _$Like {
+  const Like._();
+  const factory Like({
+    /// Like package identifier.
+    required int id,
+
+    /// Amount of like packages.
+    required int amount,
+
+    /// Like package price.
+    required int price,
+  }) = _Like;
+
+  String get likeInfo => '$amount ${_likeEnding()}';
+
+  /// Return emty like package.
+  factory Like.empty() => const Like(
+        id: 0,
+        amount: 0,
+        price: 0,
+      );
+
+  /// Get ending of string representation of likes, depend on amount of likes.
+  String _likeEnding() {
+    if (amount == 1) {
+      return "лайк";
+    } else if (amount > 1 && amount < 5) {
+      return "лайка";
+    } else {
+      return "лайков";
+    }
+  }
+}

--- a/lib/domain/store/models/like.freezed.dart
+++ b/lib/domain/store/models/like.freezed.dart
@@ -1,0 +1,192 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'like.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$LikeTearOff {
+  const _$LikeTearOff();
+
+  _Like call({required int id, required int amount, required int price}) {
+    return _Like(
+      id: id,
+      amount: amount,
+      price: price,
+    );
+  }
+}
+
+/// @nodoc
+const $Like = _$LikeTearOff();
+
+/// @nodoc
+mixin _$Like {
+  /// Like package identifier.
+  int get id => throw _privateConstructorUsedError;
+
+  /// Amount of like packages.
+  int get amount => throw _privateConstructorUsedError;
+
+  /// Like package price.
+  int get price => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $LikeCopyWith<Like> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LikeCopyWith<$Res> {
+  factory $LikeCopyWith(Like value, $Res Function(Like) then) =
+      _$LikeCopyWithImpl<$Res>;
+  $Res call({int id, int amount, int price});
+}
+
+/// @nodoc
+class _$LikeCopyWithImpl<$Res> implements $LikeCopyWith<$Res> {
+  _$LikeCopyWithImpl(this._value, this._then);
+
+  final Like _value;
+  // ignore: unused_field
+  final $Res Function(Like) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? price = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      price: price == freezed
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$LikeCopyWith<$Res> implements $LikeCopyWith<$Res> {
+  factory _$LikeCopyWith(_Like value, $Res Function(_Like) then) =
+      __$LikeCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, int amount, int price});
+}
+
+/// @nodoc
+class __$LikeCopyWithImpl<$Res> extends _$LikeCopyWithImpl<$Res>
+    implements _$LikeCopyWith<$Res> {
+  __$LikeCopyWithImpl(_Like _value, $Res Function(_Like) _then)
+      : super(_value, (v) => _then(v as _Like));
+
+  @override
+  _Like get _value => super._value as _Like;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? price = freezed,
+  }) {
+    return _then(_Like(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      price: price == freezed
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Like extends _Like {
+  const _$_Like({required this.id, required this.amount, required this.price})
+      : super._();
+
+  @override
+
+  /// Like package identifier.
+  final int id;
+  @override
+
+  /// Amount of like packages.
+  final int amount;
+  @override
+
+  /// Like package price.
+  final int price;
+
+  @override
+  String toString() {
+    return 'Like(id: $id, amount: $amount, price: $price)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Like &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.amount, amount) &&
+            const DeepCollectionEquality().equals(other.price, price));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(amount),
+      const DeepCollectionEquality().hash(price));
+
+  @JsonKey(ignore: true)
+  @override
+  _$LikeCopyWith<_Like> get copyWith =>
+      __$LikeCopyWithImpl<_Like>(this, _$identity);
+}
+
+abstract class _Like extends Like {
+  const factory _Like(
+      {required int id, required int amount, required int price}) = _$_Like;
+  const _Like._() : super._();
+
+  @override
+
+  /// Like package identifier.
+  int get id;
+  @override
+
+  /// Amount of like packages.
+  int get amount;
+  @override
+
+  /// Like package price.
+  int get price;
+  @override
+  @JsonKey(ignore: true)
+  _$LikeCopyWith<_Like> get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/domain/store/models/wallet.dart
+++ b/lib/domain/store/models/wallet.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'wallet.freezed.dart';
+
+/// Represent wallet.
+@freezed
+class Wallet with _$Wallet {
+  const Wallet._();
+  const factory Wallet({
+    /// Wallet identifier.
+    required int id,
+
+    /// Amount of likes on the account.
+    required int amount,
+
+    /// Profile identifier.
+    required int profielId,
+  }) = _Wallet;
+
+  /// Return emty walet package.
+  factory Wallet.empty() => const Wallet(
+        id: 0,
+        amount: 0,
+        profielId: 0,
+      );
+}

--- a/lib/domain/store/models/wallet.freezed.dart
+++ b/lib/domain/store/models/wallet.freezed.dart
@@ -1,0 +1,195 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'wallet.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$WalletTearOff {
+  const _$WalletTearOff();
+
+  _Wallet call({required int id, required int amount, required int profielId}) {
+    return _Wallet(
+      id: id,
+      amount: amount,
+      profielId: profielId,
+    );
+  }
+}
+
+/// @nodoc
+const $Wallet = _$WalletTearOff();
+
+/// @nodoc
+mixin _$Wallet {
+  /// Wallet identifier.
+  int get id => throw _privateConstructorUsedError;
+
+  /// Amount of likes on the account.
+  int get amount => throw _privateConstructorUsedError;
+
+  /// Profile identifier.
+  int get profielId => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $WalletCopyWith<Wallet> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WalletCopyWith<$Res> {
+  factory $WalletCopyWith(Wallet value, $Res Function(Wallet) then) =
+      _$WalletCopyWithImpl<$Res>;
+  $Res call({int id, int amount, int profielId});
+}
+
+/// @nodoc
+class _$WalletCopyWithImpl<$Res> implements $WalletCopyWith<$Res> {
+  _$WalletCopyWithImpl(this._value, this._then);
+
+  final Wallet _value;
+  // ignore: unused_field
+  final $Res Function(Wallet) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? profielId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      profielId: profielId == freezed
+          ? _value.profielId
+          : profielId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$WalletCopyWith<$Res> implements $WalletCopyWith<$Res> {
+  factory _$WalletCopyWith(_Wallet value, $Res Function(_Wallet) then) =
+      __$WalletCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, int amount, int profielId});
+}
+
+/// @nodoc
+class __$WalletCopyWithImpl<$Res> extends _$WalletCopyWithImpl<$Res>
+    implements _$WalletCopyWith<$Res> {
+  __$WalletCopyWithImpl(_Wallet _value, $Res Function(_Wallet) _then)
+      : super(_value, (v) => _then(v as _Wallet));
+
+  @override
+  _Wallet get _value => super._value as _Wallet;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? profielId = freezed,
+  }) {
+    return _then(_Wallet(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      profielId: profielId == freezed
+          ? _value.profielId
+          : profielId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_Wallet extends _Wallet {
+  const _$_Wallet(
+      {required this.id, required this.amount, required this.profielId})
+      : super._();
+
+  @override
+
+  /// Wallet identifier.
+  final int id;
+  @override
+
+  /// Amount of likes on the account.
+  final int amount;
+  @override
+
+  /// Profile identifier.
+  final int profielId;
+
+  @override
+  String toString() {
+    return 'Wallet(id: $id, amount: $amount, profielId: $profielId)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Wallet &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.amount, amount) &&
+            const DeepCollectionEquality().equals(other.profielId, profielId));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(amount),
+      const DeepCollectionEquality().hash(profielId));
+
+  @JsonKey(ignore: true)
+  @override
+  _$WalletCopyWith<_Wallet> get copyWith =>
+      __$WalletCopyWithImpl<_Wallet>(this, _$identity);
+}
+
+abstract class _Wallet extends Wallet {
+  const factory _Wallet(
+      {required int id,
+      required int amount,
+      required int profielId}) = _$_Wallet;
+  const _Wallet._() : super._();
+
+  @override
+
+  /// Wallet identifier.
+  int get id;
+  @override
+
+  /// Amount of likes on the account.
+  int get amount;
+  @override
+
+  /// Profile identifier.
+  int get profielId;
+  @override
+  @JsonKey(ignore: true)
+  _$WalletCopyWith<_Wallet> get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/domain/store/models/wallet_history.dart
+++ b/lib/domain/store/models/wallet_history.dart
@@ -1,0 +1,29 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'wallet_history.freezed.dart';
+
+/// Represent top-up history.
+@freezed
+class WalletHistory with _$WalletHistory {
+  const WalletHistory._();
+  const factory WalletHistory({
+    /// History identifier.
+    required int id,
+
+    /// Amount of added likes
+    required int amount,
+
+    /// Date and time of top-up account.
+    required String datetime,
+
+    /// Adress
+    required String address,
+  }) = _WalletHistory;
+
+  /// Return emty walet package.
+  factory WalletHistory.empty() => const WalletHistory(
+        id: 0,
+        amount: 0,
+        datetime: '',
+        address: '',
+      );
+}

--- a/lib/domain/store/models/wallet_history.freezed.dart
+++ b/lib/domain/store/models/wallet_history.freezed.dart
@@ -1,0 +1,235 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'wallet_history.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$WalletHistoryTearOff {
+  const _$WalletHistoryTearOff();
+
+  _WalletHistory call(
+      {required int id,
+      required int amount,
+      required String datetime,
+      required String address}) {
+    return _WalletHistory(
+      id: id,
+      amount: amount,
+      datetime: datetime,
+      address: address,
+    );
+  }
+}
+
+/// @nodoc
+const $WalletHistory = _$WalletHistoryTearOff();
+
+/// @nodoc
+mixin _$WalletHistory {
+  /// History identifier.
+  int get id => throw _privateConstructorUsedError;
+
+  /// Amount of added likes
+  int get amount => throw _privateConstructorUsedError;
+
+  /// Date and time of top-up account.
+  String get datetime => throw _privateConstructorUsedError;
+
+  /// Adress
+  String get address => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $WalletHistoryCopyWith<WalletHistory> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WalletHistoryCopyWith<$Res> {
+  factory $WalletHistoryCopyWith(
+          WalletHistory value, $Res Function(WalletHistory) then) =
+      _$WalletHistoryCopyWithImpl<$Res>;
+  $Res call({int id, int amount, String datetime, String address});
+}
+
+/// @nodoc
+class _$WalletHistoryCopyWithImpl<$Res>
+    implements $WalletHistoryCopyWith<$Res> {
+  _$WalletHistoryCopyWithImpl(this._value, this._then);
+
+  final WalletHistory _value;
+  // ignore: unused_field
+  final $Res Function(WalletHistory) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? datetime = freezed,
+    Object? address = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      datetime: datetime == freezed
+          ? _value.datetime
+          : datetime // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: address == freezed
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$WalletHistoryCopyWith<$Res>
+    implements $WalletHistoryCopyWith<$Res> {
+  factory _$WalletHistoryCopyWith(
+          _WalletHistory value, $Res Function(_WalletHistory) then) =
+      __$WalletHistoryCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, int amount, String datetime, String address});
+}
+
+/// @nodoc
+class __$WalletHistoryCopyWithImpl<$Res>
+    extends _$WalletHistoryCopyWithImpl<$Res>
+    implements _$WalletHistoryCopyWith<$Res> {
+  __$WalletHistoryCopyWithImpl(
+      _WalletHistory _value, $Res Function(_WalletHistory) _then)
+      : super(_value, (v) => _then(v as _WalletHistory));
+
+  @override
+  _WalletHistory get _value => super._value as _WalletHistory;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? datetime = freezed,
+    Object? address = freezed,
+  }) {
+    return _then(_WalletHistory(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      datetime: datetime == freezed
+          ? _value.datetime
+          : datetime // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: address == freezed
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_WalletHistory extends _WalletHistory {
+  const _$_WalletHistory(
+      {required this.id,
+      required this.amount,
+      required this.datetime,
+      required this.address})
+      : super._();
+
+  @override
+
+  /// History identifier.
+  final int id;
+  @override
+
+  /// Amount of added likes
+  final int amount;
+  @override
+
+  /// Date and time of top-up account.
+  final String datetime;
+  @override
+
+  /// Adress
+  final String address;
+
+  @override
+  String toString() {
+    return 'WalletHistory(id: $id, amount: $amount, datetime: $datetime, address: $address)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WalletHistory &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.amount, amount) &&
+            const DeepCollectionEquality().equals(other.datetime, datetime) &&
+            const DeepCollectionEquality().equals(other.address, address));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(amount),
+      const DeepCollectionEquality().hash(datetime),
+      const DeepCollectionEquality().hash(address));
+
+  @JsonKey(ignore: true)
+  @override
+  _$WalletHistoryCopyWith<_WalletHistory> get copyWith =>
+      __$WalletHistoryCopyWithImpl<_WalletHistory>(this, _$identity);
+}
+
+abstract class _WalletHistory extends WalletHistory {
+  const factory _WalletHistory(
+      {required int id,
+      required int amount,
+      required String datetime,
+      required String address}) = _$_WalletHistory;
+  const _WalletHistory._() : super._();
+
+  @override
+
+  /// History identifier.
+  int get id;
+  @override
+
+  /// Amount of added likes
+  int get amount;
+  @override
+
+  /// Date and time of top-up account.
+  String get datetime;
+  @override
+
+  /// Adress
+  String get address;
+  @override
+  @JsonKey(ignore: true)
+  _$WalletHistoryCopyWith<_WalletHistory> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/domain/store/repositories/i_store_reposytory.dart
+++ b/lib/domain/store/repositories/i_store_reposytory.dart
@@ -1,0 +1,20 @@
+import 'package:astra_app/domain/core/failure/astra_failure.dart';
+import 'package:astra_app/domain/store/models/like.dart';
+import 'package:astra_app/domain/store/models/wallet.dart';
+import 'package:astra_app/domain/store/models/wallet_history.dart';
+import 'package:dartz/dartz.dart';
+
+/// Describe store api service.
+abstract class IStoreReposytory {
+  /// Get like packages.
+  Future<Either<AstraFailure, List<Like>>> getLikePackages();
+
+  /// Get wallet information.
+  Future<Either<AstraFailure, Wallet>> getMyWallet();
+
+  /// Get top-up history.
+  Future<Either<AstraFailure, WalletHistory>> getTopUpHistory();
+
+  /// Top-up account.
+  Future<Either<AstraFailure, Unit>> topUpAccount(String package);
+}

--- a/lib/infrastructure/auth/repositories/auth_api_service.dart
+++ b/lib/infrastructure/auth/repositories/auth_api_service.dart
@@ -1,16 +1,22 @@
+import 'dart:developer';
+
 import 'package:astra_app/domain/auth/failures/auth_failure.dart';
 import 'package:astra_app/domain/auth/models/auth_info.dart';
 import 'package:astra_app/infrastructure/auth/DTOs/auth_info_dto.dart';
 import 'package:astra_app/infrastructure/auth/DTOs/token.dart';
+import 'package:astra_app/infrastructure/auth/extentions/dio_extensions.dart';
 import 'package:astra_app/infrastructure/auth/repositories/authenticator.dart';
 import 'package:astra_app/infrastructure/core/database/secure_strorage/i_secure_storage.dart';
 import 'package:astra_app/infrastructure/core/http/endpoints.dart';
-import 'package:astra_app/infrastructure/core/http/make_request.dart';
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/services.dart';
 import 'package:injectable/injectable.dart';
 
 import '../../../domain/auth/repositories/i_auth_api_service.dart';
+
+/// The callback request
+typedef CallBackRequest<T> = Future<T> Function();
 
 /// Service of authorization api methods.
 @LazySingleton(as: IAuthApiService)
@@ -27,7 +33,7 @@ class AuthApiService implements IAuthApiService {
 
   @override
   Future<Either<AuthFailure, Unit>> signIn(AuthInfo authInfo) async {
-    final result = await makeRequest<Unit>(() async {
+    final result = await _makeRequest<Unit>(() async {
       final response = await _dio.post(Endpoints.auth.login,
           data: AuthInfoDTO.fromDomain(authInfo));
       await _secureStorage.save(Token.fromJson(response.data));
@@ -52,11 +58,34 @@ class AuthApiService implements IAuthApiService {
 
   @override
   Future<Either<AuthFailure, bool>> checkPhoneNumber(String phone) async {
-    final result = await makeRequest<bool>(() async {
+    final result = await _makeRequest<bool>(() async {
       return await _dio.post(Endpoints.auth.checkPhone, data: {
         "phone_number": phone
       }).then((result) => result.data['success']);
     });
     return result.fold((failure) => left(failure), (success) => right(success));
+  }
+
+  /// Make http request.
+  ///
+  /// Returns [Either] there left is [AuthFailure] and right is [T].
+  Future<Either<AuthFailure, T>> _makeRequest<T>(
+    CallBackRequest callback,
+  ) async {
+    try {
+      return right(await callback());
+    } on FormatException catch (e) {
+      log("${e.message}: ${e.source}", level: 2);
+      return left(const AuthFailure.server("что то пошло не так..."));
+    } on PlatformException catch (e) {
+      log("${e.message}: ${e.code}", level: 2);
+      return left(const AuthFailure.storage());
+    } on DioError catch (e) {
+      if (e.isNoConnectionError) {
+        return left(const AuthFailure.noConnection());
+      }
+      log("${e.message}: ${e.type}", level: 2, name: "DioException");
+      return left(AuthFailure.server(e.response!.data['message']));
+    }
   }
 }

--- a/lib/infrastructure/auth/repositories/authenticator.dart
+++ b/lib/infrastructure/auth/repositories/authenticator.dart
@@ -60,7 +60,7 @@ class Authenticator {
       final token = Token(
           access: "acess token should be put here",
           refresh: "refresh token should be put here");
-      await _secureStorage.save(token);
+      // await _secureStorage.save(token);
       return right(refreshedToken.data);
     } on FormatException {
       return left(const AuthFailure.server());

--- a/lib/infrastructure/chat/chat.dart
+++ b/lib/infrastructure/chat/chat.dart
@@ -1,8 +1,8 @@
 import 'package:astra_app/infrastructure/chat/models/chat/chat.dart';
 import 'package:astra_app/infrastructure/chat/models/chat/message.dart';
+import 'package:astra_app/infrastructure/core/http/endpoints.dart';
 import 'dart:math' as math;
 import 'package:dio/dio.dart';
-import 'package:astra_app/infrastructure/core/helpers/endpoints.dart';
 import 'dart:developer';
 
 const _chars = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz1234567890';

--- a/lib/infrastructure/core/di/app_injectable_module.dart
+++ b/lib/infrastructure/core/di/app_injectable_module.dart
@@ -1,5 +1,6 @@
 import 'package:astra_app/infrastructure/core/database/sembast/sembast_database.dart';
 import 'package:dio/dio.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -22,4 +23,8 @@ abstract class AppInjectableModule {
   /// Initialized dio client.
   @lazySingleton
   Dio get dio => Dio();
+
+  /// Initizlized imagePicker service.
+  @lazySingleton
+  ImagePicker get imagePicker => ImagePicker();
 }

--- a/lib/infrastructure/core/http/dio_interceptor.dart
+++ b/lib/infrastructure/core/http/dio_interceptor.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:astra_app/infrastructure/auth/repositories/authenticator.dart';
 import 'package:dio/dio.dart';
 import 'package:injectable/injectable.dart';
@@ -21,7 +23,7 @@ class DioInterceptor extends Interceptor {
     final token = await _authenticator.getSignedToken();
     final modifiedOptions = options
       ..headers.addAll(
-        token == null ? {} : {'Authorization': 'bearer $token'},
+        token == null ? {} : {'Authorization': 'Bearer ${token.access}'},
       );
 
     handler.next(modifiedOptions);
@@ -30,8 +32,12 @@ class DioInterceptor extends Interceptor {
   @override
   Future<void> onError(DioError err, ErrorInterceptorHandler handler) async {
     final errorResponse = err.response;
-
-    if (errorResponse != null && errorResponse.statusCode == 401) {
+    //todo: workaround until backing is ready
+    final invalidToken =
+        errorResponse != null && errorResponse.data['code'] != null;
+    if (errorResponse != null &&
+        invalidToken &&
+        errorResponse.statusCode == 401) {
       final token = await _authenticator.getSignedToken();
 
       token != null

--- a/lib/infrastructure/core/http/server_address.dart
+++ b/lib/infrastructure/core/http/server_address.dart
@@ -3,5 +3,3 @@ class ServerAddress {
   final String _apiVer = "v1";
   get relevant => "$_address/$_apiVer/";
 }
-
-

--- a/lib/infrastructure/core/utils/make_request.dart
+++ b/lib/infrastructure/core/utils/make_request.dart
@@ -1,0 +1,31 @@
+import 'dart:developer';
+
+import 'package:astra_app/domain/core/failure/astra_failure.dart';
+import 'package:astra_app/infrastructure/auth/extentions/dio_extensions.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+
+/// The callback request
+typedef CallBackRequest<T> = Future<T> Function();
+
+/// Make http request.
+///
+/// Returns [Either] there left is [AuthFailure] and right is [T].
+Future<Either<AstraFailure, T>> makeRequest<T>(
+  CallBackRequest callback,
+) async {
+  try {
+    final response = await callback();
+    log("$response", name: "sucess_response");
+    return right(response);
+  } on DioError catch (e) {
+    log("${e.message}: ${e.type}", level: 2);
+    if (e.isNoConnectionError) {
+      log("${e.message}: ${e.type}", level: 2);
+      return left(const AstraFailure.noConnection());
+    } else {
+      log("${e.message}: ${e.type}", level: 2);
+      return left(const AstraFailure.api());
+    }
+  }
+}

--- a/lib/infrastructure/store/DTOs/like_dto.dart
+++ b/lib/infrastructure/store/DTOs/like_dto.dart
@@ -1,0 +1,45 @@
+import 'package:astra_app/domain/store/models/like.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'like_dto.freezed.dart';
+part 'like_dto.g.dart';
+
+/// Represent like package data transfer object.
+@freezed
+class LikeDTO with _$LikeDTO {
+  const LikeDTO._();
+  const factory LikeDTO({
+    /// Like package identifier.
+    required int id,
+
+    /// Amount of like packages.
+    required int amount,
+
+    /// Like package price.
+    required int price,
+  }) = _LikeDTO;
+
+  /// Return converted DTO from json.
+  factory LikeDTO.fromJson(Map<String, dynamic> json) =>
+      _$LikeDTOFromJson(json);
+
+  /// Convert object to json.
+  factory LikeDTO.toJson() {
+    return LikeDTO.toJson();
+  }
+
+  /// Return converted DTO from from domain.
+  factory LikeDTO.fromDomain(Like _) {
+    return LikeDTO(
+      id: _.id,
+      amount: _.amount,
+      price: _.price,
+    );
+  }
+
+  /// Convert DTO to domain.
+  Like toDomain() => Like(
+        id: id,
+        amount: amount,
+        price: price,
+      );
+}

--- a/lib/infrastructure/store/DTOs/like_dto.freezed.dart
+++ b/lib/infrastructure/store/DTOs/like_dto.freezed.dart
@@ -1,0 +1,213 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'like_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+LikeDTO _$LikeDTOFromJson(Map<String, dynamic> json) {
+  return _LikeDTO.fromJson(json);
+}
+
+/// @nodoc
+class _$LikeDTOTearOff {
+  const _$LikeDTOTearOff();
+
+  _LikeDTO call({required int id, required int amount, required int price}) {
+    return _LikeDTO(
+      id: id,
+      amount: amount,
+      price: price,
+    );
+  }
+
+  LikeDTO fromJson(Map<String, Object?> json) {
+    return LikeDTO.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $LikeDTO = _$LikeDTOTearOff();
+
+/// @nodoc
+mixin _$LikeDTO {
+  /// Like package identifier.
+  int get id => throw _privateConstructorUsedError;
+
+  /// Amount of like packages.
+  int get amount => throw _privateConstructorUsedError;
+
+  /// Like package price.
+  int get price => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $LikeDTOCopyWith<LikeDTO> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $LikeDTOCopyWith<$Res> {
+  factory $LikeDTOCopyWith(LikeDTO value, $Res Function(LikeDTO) then) =
+      _$LikeDTOCopyWithImpl<$Res>;
+  $Res call({int id, int amount, int price});
+}
+
+/// @nodoc
+class _$LikeDTOCopyWithImpl<$Res> implements $LikeDTOCopyWith<$Res> {
+  _$LikeDTOCopyWithImpl(this._value, this._then);
+
+  final LikeDTO _value;
+  // ignore: unused_field
+  final $Res Function(LikeDTO) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? price = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      price: price == freezed
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$LikeDTOCopyWith<$Res> implements $LikeDTOCopyWith<$Res> {
+  factory _$LikeDTOCopyWith(_LikeDTO value, $Res Function(_LikeDTO) then) =
+      __$LikeDTOCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, int amount, int price});
+}
+
+/// @nodoc
+class __$LikeDTOCopyWithImpl<$Res> extends _$LikeDTOCopyWithImpl<$Res>
+    implements _$LikeDTOCopyWith<$Res> {
+  __$LikeDTOCopyWithImpl(_LikeDTO _value, $Res Function(_LikeDTO) _then)
+      : super(_value, (v) => _then(v as _LikeDTO));
+
+  @override
+  _LikeDTO get _value => super._value as _LikeDTO;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? price = freezed,
+  }) {
+    return _then(_LikeDTO(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      price: price == freezed
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_LikeDTO extends _LikeDTO {
+  const _$_LikeDTO(
+      {required this.id, required this.amount, required this.price})
+      : super._();
+
+  factory _$_LikeDTO.fromJson(Map<String, dynamic> json) =>
+      _$$_LikeDTOFromJson(json);
+
+  @override
+
+  /// Like package identifier.
+  final int id;
+  @override
+
+  /// Amount of like packages.
+  final int amount;
+  @override
+
+  /// Like package price.
+  final int price;
+
+  @override
+  String toString() {
+    return 'LikeDTO(id: $id, amount: $amount, price: $price)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _LikeDTO &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.amount, amount) &&
+            const DeepCollectionEquality().equals(other.price, price));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(amount),
+      const DeepCollectionEquality().hash(price));
+
+  @JsonKey(ignore: true)
+  @override
+  _$LikeDTOCopyWith<_LikeDTO> get copyWith =>
+      __$LikeDTOCopyWithImpl<_LikeDTO>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_LikeDTOToJson(this);
+  }
+}
+
+abstract class _LikeDTO extends LikeDTO {
+  const factory _LikeDTO(
+      {required int id, required int amount, required int price}) = _$_LikeDTO;
+  const _LikeDTO._() : super._();
+
+  factory _LikeDTO.fromJson(Map<String, dynamic> json) = _$_LikeDTO.fromJson;
+
+  @override
+
+  /// Like package identifier.
+  int get id;
+  @override
+
+  /// Amount of like packages.
+  int get amount;
+  @override
+
+  /// Like package price.
+  int get price;
+  @override
+  @JsonKey(ignore: true)
+  _$LikeDTOCopyWith<_LikeDTO> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/infrastructure/store/DTOs/like_dto.g.dart
+++ b/lib/infrastructure/store/DTOs/like_dto.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'like_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_LikeDTO _$$_LikeDTOFromJson(Map<String, dynamic> json) => _$_LikeDTO(
+      id: json['id'] as int,
+      amount: json['amount'] as int,
+      price: json['price'] as int,
+    );
+
+Map<String, dynamic> _$$_LikeDTOToJson(_$_LikeDTO instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'amount': instance.amount,
+      'price': instance.price,
+    };

--- a/lib/infrastructure/store/DTOs/walet_history_dto.dart
+++ b/lib/infrastructure/store/DTOs/walet_history_dto.dart
@@ -1,0 +1,50 @@
+import 'package:astra_app/domain/store/models/wallet_history.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'walet_history_dto.freezed.dart';
+part 'walet_history_dto.g.dart';
+
+/// Represent top-up history.
+@freezed
+class WalletHistoryDTO with _$WalletHistoryDTO {
+  const WalletHistoryDTO._();
+  const factory WalletHistoryDTO({
+    /// History identifier.
+    required int id,
+
+    /// Amount of added likes
+    required int amount,
+
+    /// Date and time of top-up account.
+    required String datetime,
+
+    /// Adress
+    required String address,
+  }) = _WalletHistoryDTO;
+
+  /// Return converted DTO from json.
+  factory WalletHistoryDTO.fromJson(Map<String, dynamic> json) =>
+      _$WalletHistoryDTOFromJson(json);
+
+  /// Convert object to json.
+  factory WalletHistoryDTO.toJson() {
+    return WalletHistoryDTO.toJson();
+  }
+
+  /// Return converted DTO from from domain.
+  factory WalletHistoryDTO.fromDomain(WalletHistory _) {
+    return WalletHistoryDTO(
+      id: _.id,
+      amount: _.amount,
+      datetime: _.datetime,
+      address: _.address,
+    );
+  }
+
+  /// Convert DTO to domain.
+  WalletHistory toDomain() => WalletHistory(
+        id: id,
+        amount: amount,
+        datetime: datetime,
+        address: address,
+      );
+}

--- a/lib/infrastructure/store/DTOs/walet_history_dto.freezed.dart
+++ b/lib/infrastructure/store/DTOs/walet_history_dto.freezed.dart
@@ -1,0 +1,255 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'walet_history_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+WalletHistoryDTO _$WalletHistoryDTOFromJson(Map<String, dynamic> json) {
+  return _WalletHistoryDTO.fromJson(json);
+}
+
+/// @nodoc
+class _$WalletHistoryDTOTearOff {
+  const _$WalletHistoryDTOTearOff();
+
+  _WalletHistoryDTO call(
+      {required int id,
+      required int amount,
+      required String datetime,
+      required String address}) {
+    return _WalletHistoryDTO(
+      id: id,
+      amount: amount,
+      datetime: datetime,
+      address: address,
+    );
+  }
+
+  WalletHistoryDTO fromJson(Map<String, Object?> json) {
+    return WalletHistoryDTO.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $WalletHistoryDTO = _$WalletHistoryDTOTearOff();
+
+/// @nodoc
+mixin _$WalletHistoryDTO {
+  /// History identifier.
+  int get id => throw _privateConstructorUsedError;
+
+  /// Amount of added likes
+  int get amount => throw _privateConstructorUsedError;
+
+  /// Date and time of top-up account.
+  String get datetime => throw _privateConstructorUsedError;
+
+  /// Adress
+  String get address => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WalletHistoryDTOCopyWith<WalletHistoryDTO> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WalletHistoryDTOCopyWith<$Res> {
+  factory $WalletHistoryDTOCopyWith(
+          WalletHistoryDTO value, $Res Function(WalletHistoryDTO) then) =
+      _$WalletHistoryDTOCopyWithImpl<$Res>;
+  $Res call({int id, int amount, String datetime, String address});
+}
+
+/// @nodoc
+class _$WalletHistoryDTOCopyWithImpl<$Res>
+    implements $WalletHistoryDTOCopyWith<$Res> {
+  _$WalletHistoryDTOCopyWithImpl(this._value, this._then);
+
+  final WalletHistoryDTO _value;
+  // ignore: unused_field
+  final $Res Function(WalletHistoryDTO) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? datetime = freezed,
+    Object? address = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      datetime: datetime == freezed
+          ? _value.datetime
+          : datetime // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: address == freezed
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$WalletHistoryDTOCopyWith<$Res>
+    implements $WalletHistoryDTOCopyWith<$Res> {
+  factory _$WalletHistoryDTOCopyWith(
+          _WalletHistoryDTO value, $Res Function(_WalletHistoryDTO) then) =
+      __$WalletHistoryDTOCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, int amount, String datetime, String address});
+}
+
+/// @nodoc
+class __$WalletHistoryDTOCopyWithImpl<$Res>
+    extends _$WalletHistoryDTOCopyWithImpl<$Res>
+    implements _$WalletHistoryDTOCopyWith<$Res> {
+  __$WalletHistoryDTOCopyWithImpl(
+      _WalletHistoryDTO _value, $Res Function(_WalletHistoryDTO) _then)
+      : super(_value, (v) => _then(v as _WalletHistoryDTO));
+
+  @override
+  _WalletHistoryDTO get _value => super._value as _WalletHistoryDTO;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? datetime = freezed,
+    Object? address = freezed,
+  }) {
+    return _then(_WalletHistoryDTO(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      datetime: datetime == freezed
+          ? _value.datetime
+          : datetime // ignore: cast_nullable_to_non_nullable
+              as String,
+      address: address == freezed
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_WalletHistoryDTO extends _WalletHistoryDTO {
+  const _$_WalletHistoryDTO(
+      {required this.id,
+      required this.amount,
+      required this.datetime,
+      required this.address})
+      : super._();
+
+  factory _$_WalletHistoryDTO.fromJson(Map<String, dynamic> json) =>
+      _$$_WalletHistoryDTOFromJson(json);
+
+  @override
+
+  /// History identifier.
+  final int id;
+  @override
+
+  /// Amount of added likes
+  final int amount;
+  @override
+
+  /// Date and time of top-up account.
+  final String datetime;
+  @override
+
+  /// Adress
+  final String address;
+
+  @override
+  String toString() {
+    return 'WalletHistoryDTO(id: $id, amount: $amount, datetime: $datetime, address: $address)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WalletHistoryDTO &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.amount, amount) &&
+            const DeepCollectionEquality().equals(other.datetime, datetime) &&
+            const DeepCollectionEquality().equals(other.address, address));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(amount),
+      const DeepCollectionEquality().hash(datetime),
+      const DeepCollectionEquality().hash(address));
+
+  @JsonKey(ignore: true)
+  @override
+  _$WalletHistoryDTOCopyWith<_WalletHistoryDTO> get copyWith =>
+      __$WalletHistoryDTOCopyWithImpl<_WalletHistoryDTO>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WalletHistoryDTOToJson(this);
+  }
+}
+
+abstract class _WalletHistoryDTO extends WalletHistoryDTO {
+  const factory _WalletHistoryDTO(
+      {required int id,
+      required int amount,
+      required String datetime,
+      required String address}) = _$_WalletHistoryDTO;
+  const _WalletHistoryDTO._() : super._();
+
+  factory _WalletHistoryDTO.fromJson(Map<String, dynamic> json) =
+      _$_WalletHistoryDTO.fromJson;
+
+  @override
+
+  /// History identifier.
+  int get id;
+  @override
+
+  /// Amount of added likes
+  int get amount;
+  @override
+
+  /// Date and time of top-up account.
+  String get datetime;
+  @override
+
+  /// Adress
+  String get address;
+  @override
+  @JsonKey(ignore: true)
+  _$WalletHistoryDTOCopyWith<_WalletHistoryDTO> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/infrastructure/store/DTOs/walet_history_dto.g.dart
+++ b/lib/infrastructure/store/DTOs/walet_history_dto.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'walet_history_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_WalletHistoryDTO _$$_WalletHistoryDTOFromJson(Map<String, dynamic> json) =>
+    _$_WalletHistoryDTO(
+      id: json['id'] as int,
+      amount: json['amount'] as int,
+      datetime: json['datetime'] as String,
+      address: json['address'] as String,
+    );
+
+Map<String, dynamic> _$$_WalletHistoryDTOToJson(_$_WalletHistoryDTO instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'amount': instance.amount,
+      'datetime': instance.datetime,
+      'address': instance.address,
+    };

--- a/lib/infrastructure/store/DTOs/wallet_dto.dart
+++ b/lib/infrastructure/store/DTOs/wallet_dto.dart
@@ -1,0 +1,47 @@
+// ignore_for_file: invalid_annotation_target
+
+import 'package:astra_app/domain/store/models/wallet.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'wallet_dto.freezed.dart';
+part 'wallet_dto.g.dart';
+
+/// Represent wallet data transfer object
+@freezed
+class WalletDTO with _$WalletDTO {
+  const WalletDTO._();
+  const factory WalletDTO({
+    /// Wallet identifier.
+    required int id,
+
+    /// Amount of likes on the account.
+    required int amount,
+
+    /// Profile identifier.
+    @JsonKey(name: 'profiel_id') required int profielId,
+  }) = _WalletDTO;
+
+  /// Return converted DTO from json.
+  factory WalletDTO.fromJson(Map<String, dynamic> json) =>
+      _$WalletDTOFromJson(json);
+
+  /// Convert object to json.
+  factory WalletDTO.toJson() {
+    return WalletDTO.toJson();
+  }
+
+  /// Return converted DTO from from domain.
+  factory WalletDTO.fromDomain(Wallet _) {
+    return WalletDTO(
+      id: _.id,
+      amount: _.amount,
+      profielId: _.profielId,
+    );
+  }
+
+  /// Convert DTO to domain.
+  Wallet toDomain() => Wallet(
+        id: id,
+        amount: amount,
+        profielId: profielId,
+      );
+}

--- a/lib/infrastructure/store/DTOs/wallet_dto.freezed.dart
+++ b/lib/infrastructure/store/DTOs/wallet_dto.freezed.dart
@@ -1,0 +1,226 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'wallet_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+WalletDTO _$WalletDTOFromJson(Map<String, dynamic> json) {
+  return _WalletDTO.fromJson(json);
+}
+
+/// @nodoc
+class _$WalletDTOTearOff {
+  const _$WalletDTOTearOff();
+
+  _WalletDTO call(
+      {required int id,
+      required int amount,
+      @JsonKey(name: 'profiel_id') required int profielId}) {
+    return _WalletDTO(
+      id: id,
+      amount: amount,
+      profielId: profielId,
+    );
+  }
+
+  WalletDTO fromJson(Map<String, Object?> json) {
+    return WalletDTO.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $WalletDTO = _$WalletDTOTearOff();
+
+/// @nodoc
+mixin _$WalletDTO {
+  /// Wallet identifier.
+  int get id => throw _privateConstructorUsedError;
+
+  /// Amount of likes on the account.
+  int get amount => throw _privateConstructorUsedError;
+
+  /// Profile identifier.
+  @JsonKey(name: 'profiel_id')
+  int get profielId => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WalletDTOCopyWith<WalletDTO> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WalletDTOCopyWith<$Res> {
+  factory $WalletDTOCopyWith(WalletDTO value, $Res Function(WalletDTO) then) =
+      _$WalletDTOCopyWithImpl<$Res>;
+  $Res call({int id, int amount, @JsonKey(name: 'profiel_id') int profielId});
+}
+
+/// @nodoc
+class _$WalletDTOCopyWithImpl<$Res> implements $WalletDTOCopyWith<$Res> {
+  _$WalletDTOCopyWithImpl(this._value, this._then);
+
+  final WalletDTO _value;
+  // ignore: unused_field
+  final $Res Function(WalletDTO) _then;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? profielId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      profielId: profielId == freezed
+          ? _value.profielId
+          : profielId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$WalletDTOCopyWith<$Res> implements $WalletDTOCopyWith<$Res> {
+  factory _$WalletDTOCopyWith(
+          _WalletDTO value, $Res Function(_WalletDTO) then) =
+      __$WalletDTOCopyWithImpl<$Res>;
+  @override
+  $Res call({int id, int amount, @JsonKey(name: 'profiel_id') int profielId});
+}
+
+/// @nodoc
+class __$WalletDTOCopyWithImpl<$Res> extends _$WalletDTOCopyWithImpl<$Res>
+    implements _$WalletDTOCopyWith<$Res> {
+  __$WalletDTOCopyWithImpl(_WalletDTO _value, $Res Function(_WalletDTO) _then)
+      : super(_value, (v) => _then(v as _WalletDTO));
+
+  @override
+  _WalletDTO get _value => super._value as _WalletDTO;
+
+  @override
+  $Res call({
+    Object? id = freezed,
+    Object? amount = freezed,
+    Object? profielId = freezed,
+  }) {
+    return _then(_WalletDTO(
+      id: id == freezed
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      amount: amount == freezed
+          ? _value.amount
+          : amount // ignore: cast_nullable_to_non_nullable
+              as int,
+      profielId: profielId == freezed
+          ? _value.profielId
+          : profielId // ignore: cast_nullable_to_non_nullable
+              as int,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_WalletDTO extends _WalletDTO {
+  const _$_WalletDTO(
+      {required this.id,
+      required this.amount,
+      @JsonKey(name: 'profiel_id') required this.profielId})
+      : super._();
+
+  factory _$_WalletDTO.fromJson(Map<String, dynamic> json) =>
+      _$$_WalletDTOFromJson(json);
+
+  @override
+
+  /// Wallet identifier.
+  final int id;
+  @override
+
+  /// Amount of likes on the account.
+  final int amount;
+  @override
+
+  /// Profile identifier.
+  @JsonKey(name: 'profiel_id')
+  final int profielId;
+
+  @override
+  String toString() {
+    return 'WalletDTO(id: $id, amount: $amount, profielId: $profielId)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _WalletDTO &&
+            const DeepCollectionEquality().equals(other.id, id) &&
+            const DeepCollectionEquality().equals(other.amount, amount) &&
+            const DeepCollectionEquality().equals(other.profielId, profielId));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(id),
+      const DeepCollectionEquality().hash(amount),
+      const DeepCollectionEquality().hash(profielId));
+
+  @JsonKey(ignore: true)
+  @override
+  _$WalletDTOCopyWith<_WalletDTO> get copyWith =>
+      __$WalletDTOCopyWithImpl<_WalletDTO>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WalletDTOToJson(this);
+  }
+}
+
+abstract class _WalletDTO extends WalletDTO {
+  const factory _WalletDTO(
+      {required int id,
+      required int amount,
+      @JsonKey(name: 'profiel_id') required int profielId}) = _$_WalletDTO;
+  const _WalletDTO._() : super._();
+
+  factory _WalletDTO.fromJson(Map<String, dynamic> json) =
+      _$_WalletDTO.fromJson;
+
+  @override
+
+  /// Wallet identifier.
+  int get id;
+  @override
+
+  /// Amount of likes on the account.
+  int get amount;
+  @override
+
+  /// Profile identifier.
+  @JsonKey(name: 'profiel_id')
+  int get profielId;
+  @override
+  @JsonKey(ignore: true)
+  _$WalletDTOCopyWith<_WalletDTO> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/infrastructure/store/DTOs/wallet_dto.g.dart
+++ b/lib/infrastructure/store/DTOs/wallet_dto.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'wallet_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_WalletDTO _$$_WalletDTOFromJson(Map<String, dynamic> json) => _$_WalletDTO(
+      id: json['id'] as int,
+      amount: json['amount'] as int,
+      profielId: json['profiel_id'] as int,
+    );
+
+Map<String, dynamic> _$$_WalletDTOToJson(_$_WalletDTO instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'amount': instance.amount,
+      'profiel_id': instance.profielId,
+    };

--- a/lib/infrastructure/store/repositories/store_repository.dart
+++ b/lib/infrastructure/store/repositories/store_repository.dart
@@ -1,0 +1,59 @@
+import 'package:astra_app/domain/core/failure/astra_failure.dart';
+import 'package:astra_app/domain/store/models/like.dart';
+import 'package:astra_app/domain/store/models/wallet_history.dart';
+import 'package:astra_app/domain/store/models/wallet.dart';
+import 'package:astra_app/domain/store/repositories/i_store_reposytory.dart';
+import 'package:astra_app/infrastructure/core/http/endpoints.dart';
+import 'package:astra_app/infrastructure/core/utils/make_request.dart';
+import 'package:astra_app/infrastructure/store/DTOs/like_dto.dart';
+import 'package:astra_app/infrastructure/store/DTOs/walet_history_dto.dart';
+import 'package:astra_app/infrastructure/store/DTOs/wallet_dto.dart';
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+
+/// Defines store reposytory.
+@LazySingleton(as: IStoreReposytory)
+class StoreRepository implements IStoreReposytory {
+  /// Dio client.
+  final Dio _dio;
+
+  StoreRepository(this._dio);
+  @override
+  Future<Either<AstraFailure, List<Like>>> getLikePackages() async {
+    final result = await makeRequest(() async {
+      final response = await _dio.get(Endpoints.shop.purchaseItems);
+      return (response.data as List<dynamic>)
+          .map((e) => LikeDTO.fromJson(e).toDomain())
+          .toList();
+    });
+    return result.fold((failure) => left(failure), (success) => right(success));
+  }
+
+  @override
+  Future<Either<AstraFailure, Wallet>> getMyWallet() async {
+    final result = await makeRequest<Wallet>(() async {
+      final response = await _dio.get(Endpoints.shop.userWallet);
+      return WalletDTO.fromJson(response.data).toDomain();
+    });
+    return result.fold((failure) => left(failure), (success) => right(success));
+  }
+
+  @override
+  Future<Either<AstraFailure, WalletHistory>> getTopUpHistory() async {
+    final result = await makeRequest<WalletHistory>(() async {
+      final response = await _dio.get(Endpoints.shop.walletHistory);
+      return WalletHistoryDTO.fromJson(response.data).toDomain();
+    });
+    return result.fold((failure) => left(failure), (success) => right(success));
+  }
+
+  @override
+  Future<Either<AstraFailure, Unit>> topUpAccount(String package) async {
+    final result = await makeRequest<Unit>(() async {
+      await _dio.post(Endpoints.shop.walletAppend, data: {"package": package});
+      return unit;
+    });
+    return result.fold((failure) => left(failure), (success) => right(success));
+  }
+}

--- a/lib/injection.config.dart
+++ b/lib/injection.config.dart
@@ -7,28 +7,33 @@
 import 'package:dio/dio.dart' as _i4;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i5;
 import 'package:get_it/get_it.dart' as _i1;
+import 'package:image_picker/image_picker.dart' as _i10;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:shared_preferences/shared_preferences.dart' as _i9;
+import 'package:shared_preferences/shared_preferences.dart' as _i12;
 
-import 'application/auth/auth/auth_bloc.dart' as _i19;
+import 'application/auth/auth/auth_bloc.dart' as _i24;
 import 'application/auth/code/code_bloc.dart' as _i3;
-import 'application/auth/confirm_password/confirm_password_bloc.dart' as _i20;
-import 'application/auth/password/password_bloc.dart' as _i17;
-import 'application/auth/phone/phone_bloc.dart' as _i18;
-import 'domain/auth/repositories/i_auth_api_service.dart' as _i12;
-import 'domain/auth/repositories/i_local_storage.dart' as _i14;
-import 'infrastructure/auth/repositories/auth_api_service.dart' as _i13;
-import 'infrastructure/auth/repositories/authenticator.dart' as _i10;
-import 'infrastructure/auth/repositories/local_storage.dart' as _i15;
+import 'application/auth/confirm_password/confirm_password_bloc.dart' as _i25;
+import 'application/auth/password/password_bloc.dart' as _i22;
+import 'application/auth/phone/phone_bloc.dart' as _i23;
+import 'application/settings/store/store_actor/store_actor_bloc.dart' as _i13;
+import 'application/settings/store/store_bloc.dart' as _i14;
+import 'domain/auth/repositories/i_auth_api_service.dart' as _i17;
+import 'domain/auth/repositories/i_local_storage.dart' as _i19;
+import 'domain/store/repositories/i_store_reposytory.dart' as _i8;
+import 'infrastructure/auth/repositories/auth_api_service.dart' as _i18;
+import 'infrastructure/auth/repositories/authenticator.dart' as _i15;
+import 'infrastructure/auth/repositories/local_storage.dart' as _i20;
 import 'infrastructure/core/database/secure_strorage/i_secure_storage.dart'
     as _i6;
 import 'infrastructure/core/database/secure_strorage/secure_storage.dart'
     as _i7;
-import 'infrastructure/core/database/sembast/sembast_database.dart' as _i8;
-import 'infrastructure/core/di/app_injectable_module.dart' as _i21;
-import 'infrastructure/core/http/dio_interceptor.dart' as _i11;
-import 'infrastructure/core/repositories/local_repository.dart'
-    as _i16; // ignore_for_file: unnecessary_lambdas
+import 'infrastructure/core/database/sembast/sembast_database.dart' as _i11;
+import 'infrastructure/core/di/app_injectable_module.dart' as _i26;
+import 'infrastructure/core/http/dio_interceptor.dart' as _i16;
+import 'infrastructure/core/repositories/local_repository.dart' as _i21;
+import 'infrastructure/store/repositories/store_repository.dart'
+    as _i9; // ignore_for_file: unnecessary_lambdas
 
 // ignore_for_file: lines_longer_than_80_chars
 /// initializes the registration of provided dependencies inside of [GetIt]
@@ -42,26 +47,31 @@ Future<_i1.GetIt> $initGetIt(_i1.GetIt get,
       () => appInjectableModule.secureStorage);
   gh.lazySingleton<_i6.ISecureStorage>(
       () => _i7.SecureStorage(get<_i5.FlutterSecureStorage>()));
-  gh.lazySingleton<_i8.SembastDatabase>(() => appInjectableModule.sembastDb);
-  await gh.factoryAsync<_i9.SharedPreferences>(() => appInjectableModule.prefs,
+  gh.lazySingleton<_i8.IStoreReposytory>(
+      () => _i9.StoreRepository(get<_i4.Dio>()));
+  gh.lazySingleton<_i10.ImagePicker>(() => appInjectableModule.imagePicker);
+  gh.lazySingleton<_i11.SembastDatabase>(() => appInjectableModule.sembastDb);
+  await gh.factoryAsync<_i12.SharedPreferences>(() => appInjectableModule.prefs,
       preResolve: true);
-  gh.lazySingleton<_i10.Authenticator>(
-      () => _i10.Authenticator(get<_i4.Dio>(), get<_i6.ISecureStorage>()));
-  gh.lazySingleton<_i11.DioInterceptor>(
-      () => _i11.DioInterceptor(get<_i4.Dio>(), get<_i10.Authenticator>()));
-  gh.lazySingleton<_i12.IAuthApiService>(() => _i13.AuthApiService(
-      get<_i4.Dio>(), get<_i6.ISecureStorage>(), get<_i10.Authenticator>()));
-  gh.lazySingleton<_i14.ILocalStorage>(
-      () => _i15.LocalStorage(get<_i8.SembastDatabase>()));
-  gh.lazySingleton<_i16.LocalRepository>(
-      () => _i16.LocalRepository(get<_i9.SharedPreferences>()));
-  gh.factory<_i17.PasswordBloc>(
-      () => _i17.PasswordBloc(get<_i12.IAuthApiService>()));
-  gh.factory<_i18.PhoneBloc>(() => _i18.PhoneBloc(get<_i12.IAuthApiService>()));
-  gh.factory<_i19.AuthBloc>(() => _i19.AuthBloc(get<_i12.IAuthApiService>()));
-  gh.factory<_i20.ConfirmPasswordBloc>(
-      () => _i20.ConfirmPasswordBloc(get<_i12.IAuthApiService>()));
+  gh.factory<_i13.StoreActorBloc>(() => _i13.StoreActorBloc());
+  gh.factory<_i14.StoreBloc>(() => _i14.StoreBloc(get<_i8.IStoreReposytory>()));
+  gh.lazySingleton<_i15.Authenticator>(
+      () => _i15.Authenticator(get<_i4.Dio>(), get<_i6.ISecureStorage>()));
+  gh.lazySingleton<_i16.DioInterceptor>(
+      () => _i16.DioInterceptor(get<_i4.Dio>(), get<_i15.Authenticator>()));
+  gh.lazySingleton<_i17.IAuthApiService>(() => _i18.AuthApiService(
+      get<_i4.Dio>(), get<_i6.ISecureStorage>(), get<_i15.Authenticator>()));
+  gh.lazySingleton<_i19.ILocalStorage>(
+      () => _i20.LocalStorage(get<_i11.SembastDatabase>()));
+  gh.lazySingleton<_i21.LocalRepository>(
+      () => _i21.LocalRepository(get<_i12.SharedPreferences>()));
+  gh.factory<_i22.PasswordBloc>(
+      () => _i22.PasswordBloc(get<_i17.IAuthApiService>()));
+  gh.factory<_i23.PhoneBloc>(() => _i23.PhoneBloc(get<_i17.IAuthApiService>()));
+  gh.factory<_i24.AuthBloc>(() => _i24.AuthBloc(get<_i17.IAuthApiService>()));
+  gh.factory<_i25.ConfirmPasswordBloc>(
+      () => _i25.ConfirmPasswordBloc(get<_i17.IAuthApiService>()));
   return get;
 }
 
-class _$AppInjectableModule extends _i21.AppInjectableModule {}
+class _$AppInjectableModule extends _i26.AppInjectableModule {}

--- a/lib/presentation/astra/home_screen.dart
+++ b/lib/presentation/astra/home_screen.dart
@@ -1,3 +1,4 @@
+import 'package:astra_app/presentation/core/enums/store_screen_qualifier.dart';
 import 'package:astra_app/presentation/core/routes/app_router.gr.dart';
 import 'package:astra_app/presentation/core/widgets/scaffolds/navigation_bar.dart';
 import 'package:auto_route/auto_route.dart';

--- a/lib/presentation/astra/profile/profile_screen.dart
+++ b/lib/presentation/astra/profile/profile_screen.dart
@@ -92,7 +92,7 @@ class ProfileScreen extends StatelessWidget {
                   ),
                   title: 'Магазин',
                   onTap: () {
-                    AutoRouter.of(context).push(const StoreScreenRoute());
+                    AutoRouter.of(context).push(StoreScreenRoute());
                   },
                 ),
                 ProfileItem(

--- a/lib/presentation/astra/store/widgets/astra_check_box.dart
+++ b/lib/presentation/astra/store/widgets/astra_check_box.dart
@@ -1,0 +1,47 @@
+import 'package:astra_app/presentation/core/theming/colors.dart';
+import 'package:flutter/material.dart';
+
+/// Simple checknox.
+class AstraChekBox extends StatefulWidget {
+  const AstraChekBox({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<AstraChekBox> createState() => _AstraChekBoxState();
+}
+
+class _AstraChekBoxState extends State<AstraChekBox> {
+  bool chekBoxValue = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 12, top: 24),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Checkbox(
+            value: chekBoxValue,
+            side: MaterialStateBorderSide.resolveWith(
+              (states) =>
+                  const BorderSide(width: 1.0, color: AstraColors.darkGrey),
+            ),
+            fillColor: MaterialStateColor.resolveWith((states) => Colors.white),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+            checkColor: AstraColors.darkGrey,
+            onChanged: (value) {
+              chekBoxValue = value!;
+              setState(() {});
+            },
+          ),
+          const Text(
+            'Автоматически обновлять покупку когда \nзакончатся лайки',
+            style: TextStyle(color: AstraColors.darkGrey, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/astra/store/widgets/grouped_selected_like_packages.dart
+++ b/lib/presentation/astra/store/widgets/grouped_selected_like_packages.dart
@@ -1,0 +1,36 @@
+import 'package:astra_app/domain/store/models/like.dart';
+import 'package:astra_app/presentation/core/widgets/buttons/astra_bordered_button.dart';
+import 'package:flutter/material.dart';
+
+/// Defines buttons for selecting like package.
+class GroupedSelectedLikePackages extends StatelessWidget {
+  /// Initial like packages.
+  final List<Like> likes;
+
+  /// Selected like.
+  final Like selectedLike;
+
+  /// Event handler of celecting like package.
+  final Function(Like) onSelectLike;
+  const GroupedSelectedLikePackages(
+      {Key? key,
+      required this.likes,
+      required this.selectedLike,
+      required this.onSelectLike})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+        children: likes
+            .map((item) => Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: AstraBorderredButton(
+                    onTap: () => onSelectLike(item),
+                    title: item.likeInfo,
+                    withBorder: item.id != selectedLike.id,
+                  ),
+                ))
+            .toList());
+  }
+}

--- a/lib/presentation/auth/password_screen.dart
+++ b/lib/presentation/auth/password_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:developer';
-
 import 'package:astra_app/application/auth/auth/auth_bloc.dart';
 import 'package:astra_app/application/auth/password/password_bloc.dart';
 import 'package:astra_app/injection.dart';

--- a/lib/presentation/core/enums/store_screen_qualifier.dart
+++ b/lib/presentation/core/enums/store_screen_qualifier.dart
@@ -1,0 +1,8 @@
+/// Enumerates current store screens.
+enum StoreScreenQualifier {
+  /// Store screen for settings.
+  storeSettings,
+
+  /// Strore screen for after registration.
+  storeAfterRegistration,
+}

--- a/lib/presentation/core/routes/app_router.dart
+++ b/lib/presentation/core/routes/app_router.dart
@@ -7,10 +7,10 @@ import 'package:astra_app/presentation/astra/profile/my_pofile/my_profile.dart';
 import 'package:astra_app/presentation/astra/profile/my_pofile/photo/image_pick_screen.dart';
 import 'package:astra_app/presentation/astra/profile/my_pofile/photo/show_image_full_screen.dart';
 import 'package:astra_app/presentation/astra/profile/profile_screen.dart';
-import 'package:astra_app/presentation/astra/profile/store/store_screen.dart';
 import 'package:astra_app/presentation/astra/profile/support/support_screen.dart';
 import 'package:astra_app/presentation/astra/search/search_detail.dart';
 import 'package:astra_app/presentation/astra/search/search_screen.dart';
+import 'package:astra_app/presentation/astra/store/store_screen.dart';
 import 'package:astra_app/presentation/auth/code_screen.dart';
 import 'package:astra_app/presentation/auth/confirm_password_screen.dart';
 import 'package:astra_app/presentation/auth/how_to_get_club_screen.dart';
@@ -29,8 +29,8 @@ import 'package:auto_route/auto_route.dart';
     MaterialRoute(page: CodeScreen),
     MaterialRoute(page: PasswordScreen),
     MaterialRoute(page: ConfirmPasswordScreen),
-    MaterialRoute(page: StoreScreen),
     MaterialRoute(page: FinishRegisterScreen),
+    MaterialRoute(page: ImagePickScreen),
     AutoRoute(
       path: '',
       page: HomeScreen,
@@ -65,10 +65,10 @@ import 'package:auto_route/auto_route.dart';
           children: [
             AutoRoute(path: '', page: ProfileScreen),
             AutoRoute(path: ':showImageFullScreen', page: ShowImageFullScreen),
-            AutoRoute(path: ':imagePickScreen', page: ImagePickScreen),
             AutoRoute(path: ':myProfileScreen', page: MyProfileScreen),
             AutoRoute(path: ':aboutScreen', page: AboutScreen),
             AutoRoute(path: ':supportScreen', page: SupportScreen),
+            AutoRoute(path: ':store', page: StoreScreen),
           ],
         ),
       ],

--- a/lib/presentation/core/routes/app_router.gr.dart
+++ b/lib/presentation/core/routes/app_router.gr.dart
@@ -9,32 +9,32 @@
 // **************************************************************************
 
 import 'package:auto_route/auto_route.dart' as _i10;
-import 'package:flutter/cupertino.dart' as _i23;
 import 'package:flutter/material.dart' as _i22;
 
-import '../../../infrastructure/chat/models/chat/chat.dart' as _i24;
-import '../../../infrastructure/chat/models/chat/message.dart' as _i25;
+import '../../../infrastructure/chat/models/chat/chat.dart' as _i23;
+import '../../../infrastructure/chat/models/chat/message.dart' as _i24;
 import '../../astra/favorite/favorite_screen.dart' as _i11;
 import '../../astra/home_screen.dart' as _i9;
 import '../../astra/message/chat_screen.dart' as _i15;
 import '../../astra/message/message_screen.dart' as _i12;
-import '../../astra/profile/about/about_screen.dart' as _i20;
-import '../../astra/profile/my_pofile/my_profile.dart' as _i19;
-import '../../astra/profile/my_pofile/photo/image_pick_screen.dart' as _i18;
+import '../../astra/profile/about/about_screen.dart' as _i19;
+import '../../astra/profile/my_pofile/my_profile.dart' as _i18;
+import '../../astra/profile/my_pofile/photo/image_pick_screen.dart' as _i8;
 import '../../astra/profile/my_pofile/photo/show_image_full_screen.dart'
     as _i17;
 import '../../astra/profile/profile_screen.dart' as _i16;
-import '../../astra/profile/store/store_screen.dart' as _i7;
-import '../../astra/profile/support/support_screen.dart' as _i21;
+import '../../astra/profile/support/support_screen.dart' as _i20;
 import '../../astra/search/search_detail.dart' as _i14;
 import '../../astra/search/search_screen.dart' as _i13;
+import '../../astra/store/store_screen.dart' as _i21;
 import '../../auth/code_screen.dart' as _i4;
 import '../../auth/confirm_password_screen.dart' as _i6;
 import '../../auth/how_to_get_club_screen.dart' as _i3;
 import '../../auth/password_screen.dart' as _i5;
 import '../../auth/phone_number_screen.dart' as _i2;
 import '../../auth/splash_screen.dart' as _i1;
-import '../../auth/widgets/finish_register_screen.dart' as _i8;
+import '../../auth/widgets/finish_register_screen.dart' as _i7;
+import '../enums/store_screen_qualifier.dart' as _i25;
 
 class AppRouter extends _i10.RootStackRouter {
   AppRouter([_i22.GlobalKey<_i22.NavigatorState>? navigatorKey])
@@ -76,13 +76,13 @@ class AppRouter extends _i10.RootStackRouter {
               phoneNumber: args.phoneNumber,
               confirmePassword: args.confirmePassword));
     },
-    StoreScreenRoute.name: (routeData) {
-      return _i10.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i7.StoreScreen());
-    },
     FinishRegisterScreenRoute.name: (routeData) {
       return _i10.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i8.FinishRegisterScreen());
+          routeData: routeData, child: const _i7.FinishRegisterScreen());
+    },
+    ImagePickScreenRoute.name: (routeData) {
+      return _i10.MaterialPageX<dynamic>(
+          routeData: routeData, child: const _i8.ImagePickScreen());
     },
     HomeScreenRoute.name: (routeData) {
       return _i10.MaterialPageX<dynamic>(
@@ -127,21 +127,25 @@ class AppRouter extends _i10.RootStackRouter {
       return _i10.MaterialPageX<dynamic>(
           routeData: routeData, child: const _i17.ShowImageFullScreen());
     },
-    ImagePickScreenRoute.name: (routeData) {
-      return _i10.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i18.ImagePickScreen());
-    },
     MyProfileScreenRoute.name: (routeData) {
       return _i10.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i19.MyProfileScreen());
+          routeData: routeData, child: const _i18.MyProfileScreen());
     },
     AboutScreenRoute.name: (routeData) {
       return _i10.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i20.AboutScreen());
+          routeData: routeData, child: const _i19.AboutScreen());
     },
     SupportScreenRoute.name: (routeData) {
       return _i10.MaterialPageX<dynamic>(
-          routeData: routeData, child: const _i21.SupportScreen());
+          routeData: routeData, child: const _i20.SupportScreen());
+    },
+    StoreScreenRoute.name: (routeData) {
+      final args = routeData.argsAs<StoreScreenRouteArgs>(
+          orElse: () => const StoreScreenRouteArgs());
+      return _i10.MaterialPageX<dynamic>(
+          routeData: routeData,
+          child: _i21.StoreScreen(
+              key: args.key, storeQualifer: args.storeQualifer));
     }
   };
 
@@ -156,9 +160,9 @@ class AppRouter extends _i10.RootStackRouter {
         _i10.RouteConfig(PasswordScreenRoute.name, path: '/password-screen'),
         _i10.RouteConfig(ConfirmPasswordScreenRoute.name,
             path: '/confirm-password-screen'),
-        _i10.RouteConfig(StoreScreenRoute.name, path: '/store-screen'),
         _i10.RouteConfig(FinishRegisterScreenRoute.name,
             path: '/finish-register-screen'),
+        _i10.RouteConfig(ImagePickScreenRoute.name, path: '/image-pick-screen'),
         _i10.RouteConfig(HomeScreenRoute.name, path: '', children: [
           _i10.RouteConfig(SearchRouter.name,
               path: 'searche',
@@ -186,14 +190,14 @@ class AppRouter extends _i10.RootStackRouter {
                     path: '', parent: SettingsRouter.name),
                 _i10.RouteConfig(ShowImageFullScreenRoute.name,
                     path: ':showImageFullScreen', parent: SettingsRouter.name),
-                _i10.RouteConfig(ImagePickScreenRoute.name,
-                    path: ':imagePickScreen', parent: SettingsRouter.name),
                 _i10.RouteConfig(MyProfileScreenRoute.name,
                     path: ':myProfileScreen', parent: SettingsRouter.name),
                 _i10.RouteConfig(AboutScreenRoute.name,
                     path: ':aboutScreen', parent: SettingsRouter.name),
                 _i10.RouteConfig(SupportScreenRoute.name,
-                    path: ':supportScreen', parent: SettingsRouter.name)
+                    path: ':supportScreen', parent: SettingsRouter.name),
+                _i10.RouteConfig(StoreScreenRoute.name,
+                    path: ':store', parent: SettingsRouter.name)
               ])
         ])
       ];
@@ -223,7 +227,7 @@ class HowToGetClubScreenRoute extends _i10.PageRouteInfo<void> {
 
 /// generated route for [_i4.CodeScreen]
 class CodeScreenRoute extends _i10.PageRouteInfo<CodeScreenRouteArgs> {
-  CodeScreenRoute({_i23.Key? key, required String phoneNumber})
+  CodeScreenRoute({_i22.Key? key, required String phoneNumber})
       : super(name,
             path: '/code-screen',
             args: CodeScreenRouteArgs(key: key, phoneNumber: phoneNumber));
@@ -234,7 +238,7 @@ class CodeScreenRoute extends _i10.PageRouteInfo<CodeScreenRouteArgs> {
 class CodeScreenRouteArgs {
   const CodeScreenRouteArgs({this.key, required this.phoneNumber});
 
-  final _i23.Key? key;
+  final _i22.Key? key;
 
   final String phoneNumber;
 
@@ -247,7 +251,7 @@ class CodeScreenRouteArgs {
 /// generated route for [_i5.PasswordScreen]
 class PasswordScreenRoute extends _i10.PageRouteInfo<PasswordScreenRouteArgs> {
   PasswordScreenRoute(
-      {_i23.Key? key, required String phoneNumber, String? code})
+      {_i22.Key? key, required String phoneNumber, String? code})
       : super(name,
             path: '/password-screen',
             args: PasswordScreenRouteArgs(
@@ -260,7 +264,7 @@ class PasswordScreenRouteArgs {
   const PasswordScreenRouteArgs(
       {this.key, required this.phoneNumber, this.code});
 
-  final _i23.Key? key;
+  final _i22.Key? key;
 
   final String phoneNumber;
 
@@ -276,7 +280,7 @@ class PasswordScreenRouteArgs {
 class ConfirmPasswordScreenRoute
     extends _i10.PageRouteInfo<ConfirmPasswordScreenRouteArgs> {
   ConfirmPasswordScreenRoute(
-      {_i23.Key? key,
+      {_i22.Key? key,
       required String phoneNumber,
       required String confirmePassword})
       : super(name,
@@ -293,7 +297,7 @@ class ConfirmPasswordScreenRouteArgs {
   const ConfirmPasswordScreenRouteArgs(
       {this.key, required this.phoneNumber, required this.confirmePassword});
 
-  final _i23.Key? key;
+  final _i22.Key? key;
 
   final String phoneNumber;
 
@@ -305,19 +309,19 @@ class ConfirmPasswordScreenRouteArgs {
   }
 }
 
-/// generated route for [_i7.StoreScreen]
-class StoreScreenRoute extends _i10.PageRouteInfo<void> {
-  const StoreScreenRoute() : super(name, path: '/store-screen');
-
-  static const String name = 'StoreScreenRoute';
-}
-
-/// generated route for [_i8.FinishRegisterScreen]
+/// generated route for [_i7.FinishRegisterScreen]
 class FinishRegisterScreenRoute extends _i10.PageRouteInfo<void> {
   const FinishRegisterScreenRoute()
       : super(name, path: '/finish-register-screen');
 
   static const String name = 'FinishRegisterScreenRoute';
+}
+
+/// generated route for [_i8.ImagePickScreen]
+class ImagePickScreenRoute extends _i10.PageRouteInfo<void> {
+  const ImagePickScreenRoute() : super(name, path: '/image-pick-screen');
+
+  static const String name = 'ImagePickScreenRoute';
 }
 
 /// generated route for [_i9.HomeScreen]
@@ -377,9 +381,9 @@ class SearchDetailPageRoute extends _i10.PageRouteInfo<void> {
 class MessageChatScreenRoute
     extends _i10.PageRouteInfo<MessageChatScreenRouteArgs> {
   MessageChatScreenRoute(
-      {_i23.Key? key,
-      required _i24.Chat chat,
-      required _i25.Message lastMessage})
+      {_i22.Key? key,
+      required _i23.Chat chat,
+      required _i24.Message lastMessage})
       : super(name,
             path: '',
             args: MessageChatScreenRouteArgs(
@@ -392,11 +396,11 @@ class MessageChatScreenRouteArgs {
   const MessageChatScreenRouteArgs(
       {this.key, required this.chat, required this.lastMessage});
 
-  final _i23.Key? key;
+  final _i22.Key? key;
 
-  final _i24.Chat chat;
+  final _i23.Chat chat;
 
-  final _i25.Message lastMessage;
+  final _i24.Message lastMessage;
 
   @override
   String toString() {
@@ -418,30 +422,50 @@ class ShowImageFullScreenRoute extends _i10.PageRouteInfo<void> {
   static const String name = 'ShowImageFullScreenRoute';
 }
 
-/// generated route for [_i18.ImagePickScreen]
-class ImagePickScreenRoute extends _i10.PageRouteInfo<void> {
-  const ImagePickScreenRoute() : super(name, path: ':imagePickScreen');
-
-  static const String name = 'ImagePickScreenRoute';
-}
-
-/// generated route for [_i19.MyProfileScreen]
+/// generated route for [_i18.MyProfileScreen]
 class MyProfileScreenRoute extends _i10.PageRouteInfo<void> {
   const MyProfileScreenRoute() : super(name, path: ':myProfileScreen');
 
   static const String name = 'MyProfileScreenRoute';
 }
 
-/// generated route for [_i20.AboutScreen]
+/// generated route for [_i19.AboutScreen]
 class AboutScreenRoute extends _i10.PageRouteInfo<void> {
   const AboutScreenRoute() : super(name, path: ':aboutScreen');
 
   static const String name = 'AboutScreenRoute';
 }
 
-/// generated route for [_i21.SupportScreen]
+/// generated route for [_i20.SupportScreen]
 class SupportScreenRoute extends _i10.PageRouteInfo<void> {
   const SupportScreenRoute() : super(name, path: ':supportScreen');
 
   static const String name = 'SupportScreenRoute';
+}
+
+/// generated route for [_i21.StoreScreen]
+class StoreScreenRoute extends _i10.PageRouteInfo<StoreScreenRouteArgs> {
+  StoreScreenRoute(
+      {_i22.Key? key,
+      _i25.StoreScreenQualifier storeQualifer =
+          _i25.StoreScreenQualifier.storeSettings})
+      : super(name,
+            path: ':store',
+            args: StoreScreenRouteArgs(key: key, storeQualifer: storeQualifer));
+
+  static const String name = 'StoreScreenRoute';
+}
+
+class StoreScreenRouteArgs {
+  const StoreScreenRouteArgs(
+      {this.key, this.storeQualifer = _i25.StoreScreenQualifier.storeSettings});
+
+  final _i22.Key? key;
+
+  final _i25.StoreScreenQualifier storeQualifer;
+
+  @override
+  String toString() {
+    return 'StoreScreenRouteArgs{key: $key, storeQualifer: $storeQualifer}';
+  }
 }

--- a/lib/presentation/core/widgets/scaffolds/error_screen.dart
+++ b/lib/presentation/core/widgets/scaffolds/error_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+const _error = 'Что-то пошло не так....';
+
+/// Defines screen, that usually showing she get unexpected failure.
+class ErrorScreen extends StatelessWidget {
+  final String errorTitle;
+  const ErrorScreen({Key? key, this.errorTitle = _error}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: Center(
+      child: Text(errorTitle),
+    ));
+  }
+}

--- a/lib/presentation/core/widgets/scaffolds/loading_screen.dart
+++ b/lib/presentation/core/widgets/scaffolds/loading_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Defines screen, when data loading.
+class LoadingScreen extends StatelessWidget {
+  const LoadingScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Align(
+        alignment: Alignment.center,
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -272,6 +272,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.0.0"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.18.1"
   flutter_lints:
     dependency: "direct main"
     description:
@@ -675,7 +682,7 @@ packages:
     source: hosted
     version: "4.2.4"
   provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: provider
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_bloc: ^8.0.0
+  flutter_hooks: ^0.18.1
   flutter_lints: ^1.0.0
   flutter_secure_storage: ^5.0.2
   flutter_svg: ^0.23.0+1
@@ -52,6 +53,7 @@ dependencies:
   mask_text_input_formatter: ^2.0.0
   path_provider: ^2.0.7
   pin_code_fields: ^7.3.0
+  provider: ^6.0.1
   sembast: ^3.1.1
   shared_preferences: ^2.0.9
 


### PR DESCRIPTION
Реализовал частичную интеграцию  с сервером в на экране Store. 
Не реализовал истоию кошелька, информацию по кошельку и выполнения покупки "Лайков" через Apple pay.
Историю кошелька не реализовал по причине того, что не нашел этот функцианал в GUI. Так же это касается и информацию по кошельку(Нашел этот функцианал в GUI реалзую в рамках задачи связанной с интеграцие профиля).
Apple pay Нет возвожности реализовать, т.к. пока нету MAC OS. 


